### PR TITLE
fix: coding tool hints, Swift timeout bump, coding agent logging

### DIFF
--- a/jarvis-core/tests/test_tools_coding_agent.py
+++ b/jarvis-core/tests/test_tools_coding_agent.py
@@ -121,7 +121,9 @@ def test_ask_returns_answer(tmp_path):
 
     assert result["answer"] == "The router classifies intent before execution."
     assert result["error"] is None
-    mock_loop.ask.assert_called_once_with("what does the router do?")
+    call_kwargs = mock_loop.ask.call_args
+    assert call_kwargs.args[0] == "what does the router do?"
+    assert "on_event" in call_kwargs.kwargs
 
 
 def test_ask_returns_error_on_exception(tmp_path):

--- a/jarvis-core/tools/coding_agent.py
+++ b/jarvis-core/tools/coding_agent.py
@@ -1,7 +1,10 @@
 import hashlib
+import logging
 import os
 import subprocess
 import sys
+
+_log = logging.getLogger("jarvis.coding_agent")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'ai-coding-agent')))
 
@@ -56,15 +59,26 @@ class CodingAgentTool:
         return store
 
     def ask(self, question: str, cwd: str) -> dict:
+        llm_model = getattr(self._llm, "model", "unknown")
+        _log.info("coding_ask starting — model=%s cwd=%s", llm_model, cwd)
         try:
             store = self._ensure_indexed(cwd)
             loop = AgentLoop(self._llm, self._embedder, store, repo_root=cwd)
-            answer = loop.ask(question)
+
+            def _on_event(event: str, data: dict) -> None:
+                if event == "model_fallback":
+                    _log.warning("coding_ask model fallback — kind=%s reason=%s", data.get("kind"), data.get("reason"))
+
+            answer = loop.ask(question, on_event=_on_event)
             return {"answer": answer, "error": None}
         except Exception as e:
+            _log.error("coding_ask failed — %s", e)
             return {"answer": None, "error": str(e)}
 
     def plan(self, task: str, cwd: str) -> dict:
+        # Planner calls llm.client.messages.create() directly — always uses Claude (not local model)
+        llm_model = getattr(self._llm, "model", "unknown")
+        _log.info("coding_plan starting — model=%s (direct API, local model bypassed) cwd=%s", llm_model, cwd)
         try:
             store = self._ensure_indexed(cwd)
             planner = Planner(self._llm, self._embedder, store, repo_root=cwd)
@@ -83,11 +97,16 @@ class CodingAgentTool:
                 summary_lines.append(f"• {e.file}: {e.description}")
             return {"plan_summary": "\n".join(summary_lines), "edits": edits, "error": None}
         except PlannerError as e:
+            _log.error("coding_plan failed — %s", e)
             return {"plan_summary": None, "edits": None, "error": str(e)}
         except Exception as e:
+            _log.error("coding_plan failed — %s", e)
             return {"plan_summary": None, "edits": None, "error": str(e)}
 
     def review(self, cwd: str, context: str = "") -> dict:
+        # Reviewer calls llm.client.messages.create() directly — always uses Claude (not local model)
+        llm_model = getattr(self._llm, "model", "unknown")
+        _log.info("coding_review starting — model=%s (direct API, local model bypassed) cwd=%s", llm_model, cwd)
         try:
             proc = subprocess.run(
                 ["git", "diff", "HEAD"],
@@ -115,6 +134,8 @@ class CodingAgentTool:
             ]
             return {"summary": result.summary, "issues": issues, "error": None}
         except ReviewerError as e:
+            _log.error("coding_review failed — %s", e)
             return {"summary": None, "issues": None, "error": str(e)}
         except Exception as e:
+            _log.error("coding_review failed — %s", e)
             return {"summary": None, "issues": None, "error": str(e)}

--- a/jarvis-swift/Jarvis/AudioController.swift
+++ b/jarvis-swift/Jarvis/AudioController.swift
@@ -302,7 +302,7 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
         let stepVoice = stepVoiceEnabled
         guard let url = URL(string: "http://127.0.0.1:8765/events/\(commandId)") else { return }
         var request = URLRequest(url: url)
-        request.timeoutInterval = 180
+        request.timeoutInterval = 600
 
         do {
             let (stream, _) = try await URLSession.shared.bytes(for: request)


### PR DESCRIPTION
## Summary
- **Swift timeout 180s → 600s** — `coding_plan` takes 200-255s (Planner/Reviewer always use Claude directly); client was disconnecting before server finished
- **`coding_ask/plan/review` finalize hints** — tool descriptions now say "call finalize immediately after" — fixes executor looping after a complete result
- **`jarvis.coding_agent` logging** — logs model in use on each call; notes that Planner/Reviewer bypass the local model; logs `model_fallback` events when `coding_ask` falls back from qwen3-coder to Haiku

## Key finding
`Planner` and `Reviewer` call `self.llm.client.messages.create()` directly — on `HybridClient` this always returns the Claude (Haiku) client. The local model is bypassed entirely for `coding_plan` and `coding_review`. Logged clearly so it shows up in `~/.jarvis/logs/errors.log`.

## Test plan
- [ ] Rebuild Swift app (⌘B)
- [ ] Restart Jarvis, ask "review the recent changes" → should complete without "Lost connection"
- [ ] Ask "create a plan to fix X" → should complete (may still be slow, now has 600s)
- [ ] Check `~/.jarvis/logs/errors.log` for `coding_agent` entries showing model used
- [ ] 306 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)