### PR TITLE
feat: coding agent local-first routing and plan persistence

### DIFF
--- a/jarvis-core/ollama_agent.py
+++ b/jarvis-core/ollama_agent.py
@@ -20,6 +20,8 @@ CRITICAL RULES FOR THIS MODEL:
 - NEVER claim to have performed an action without first calling the tool. No tool call = no action taken.
 - Be efficient: once you have enough information to answer, stop calling tools and respond. Do NOT keep gathering extra data beyond what the user asked for.
 - You have a limited number of tool calls. Use only what is needed — typically 1-3 calls. Do not explore tangents.
+- CODING TOOLS RULE: After calling coding_ask, coding_plan, or coding_review — call finalize IMMEDIATELY. These tools return complete answers. Do NOT call shell_run, file_read, list_dir, find_files, or any other tool after them. One coding tool call → finalize. That is the entire sequence.
+- NEVER call mkdir, file_write, or any filesystem-modifying command unless the user explicitly asked you to create or write something. Answering a question does not require creating directories or files.
 """
 
 

--- a/jarvis-core/tests/test_tools_coding_agent.py
+++ b/jarvis-core/tests/test_tools_coding_agent.py
@@ -187,12 +187,15 @@ def _make_plan_mock():
 
 
 def test_plan_returns_edits(tmp_path):
-    """plan() calls Planner.plan and returns formatted edits."""
+    """plan() calls Planner.plan, saves the plan, and returns formatted edits."""
+    import os
     cwd = str(tmp_path)
+    repo_name = os.path.basename(cwd.rstrip("/"))
     with patch("tools.coding_agent.ClaudeClient"), \
          patch("tools.coding_agent.OllamaEmbedder"), \
          patch("tools.coding_agent.VectorStore") as MockStore, \
          patch("tools.coding_agent.index_repo"), \
+         patch("tools.coding_agent.save_plan") as mock_save_plan, \
          patch("tools.coding_agent.Planner") as MockPlanner:
         mock_store = MagicMock()
         mock_store.count.return_value = 5
@@ -201,6 +204,7 @@ def test_plan_returns_edits(tmp_path):
         mock_planner = MagicMock()
         mock_planner.plan.return_value = _make_plan_mock()
         MockPlanner.return_value = mock_planner
+        mock_save_plan.return_value = "/tmp/fake-plan.json"
 
         tool = make_tool()
         result = tool.plan("extract auth into a service", cwd)
@@ -210,7 +214,9 @@ def test_plan_returns_edits(tmp_path):
     assert result["edits"][0]["file"] == "auth/service.py"
     assert result["edits"][0]["old_code"] == "def authenticate(user):\n    pass"
     assert "plan_summary" in result
-    mock_planner.plan.assert_called_once_with("extract auth into a service", cwd)
+    assert result["plan_path"] == "/tmp/fake-plan.json"
+    mock_planner.plan.assert_called_once_with("extract auth into a service", repo=repo_name)
+    mock_save_plan.assert_called_once()
 
 
 def test_plan_returns_error_on_planner_error(tmp_path):

--- a/jarvis-core/tools/coding_agent.py
+++ b/jarvis-core/tools/coding_agent.py
@@ -11,6 +11,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..',
 from src.agent_loop import AgentLoop
 from src.planner import Planner, PlannerError
 from src.reviewer import Reviewer, ReviewerError
+from src.plan_store import save_plan
 from src.indexer import index_repo
 from src.llm import ClaudeClient
 from src.ollama_client import OllamaClient
@@ -20,6 +21,7 @@ from src.store import VectorStore
 
 
 _CHROMA_PATH = os.path.expanduser("~/.jarvis/coding-agent-chroma")
+_PLANS_DIR = os.path.expanduser("~/.jarvis/coding-agent-plans")
 
 
 class CodingAgentTool:
@@ -76,13 +78,15 @@ class CodingAgentTool:
             return {"answer": None, "error": str(e)}
 
     def plan(self, task: str, cwd: str) -> dict:
-        # Planner calls llm.client.messages.create() directly — always uses Claude (not local model)
         llm_model = getattr(self._llm, "model", "unknown")
-        _log.info("coding_plan starting — model=%s (direct API, local model bypassed) cwd=%s", llm_model, cwd)
+        _log.info("coding_plan starting — model=%s cwd=%s", llm_model, cwd)
         try:
             store = self._ensure_indexed(cwd)
+            repo_name = os.path.basename(cwd.rstrip("/"))
             planner = Planner(self._llm, self._embedder, store, repo_root=cwd)
-            result = planner.plan(task, cwd)
+            result = planner.plan(task, repo=repo_name)
+            plan_path = save_plan(result, _PLANS_DIR)
+            _log.info("coding_plan saved — path=%s edits=%d", plan_path, len(result.edits))
             edits = [
                 {
                     "file": e.file,
@@ -95,7 +99,7 @@ class CodingAgentTool:
             summary_lines = [f"Plan: {task}", ""]
             for e in result.edits:
                 summary_lines.append(f"• {e.file}: {e.description}")
-            return {"plan_summary": "\n".join(summary_lines), "edits": edits, "error": None}
+            return {"plan_summary": "\n".join(summary_lines), "edits": edits, "plan_path": str(plan_path), "error": None}
         except PlannerError as e:
             _log.error("coding_plan failed — %s", e)
             return {"plan_summary": None, "edits": None, "error": str(e)}
@@ -104,9 +108,8 @@ class CodingAgentTool:
             return {"plan_summary": None, "edits": None, "error": str(e)}
 
     def review(self, cwd: str, context: str = "") -> dict:
-        # Reviewer calls llm.client.messages.create() directly — always uses Claude (not local model)
         llm_model = getattr(self._llm, "model", "unknown")
-        _log.info("coding_review starting — model=%s (direct API, local model bypassed) cwd=%s", llm_model, cwd)
+        _log.info("coding_review starting — model=%s cwd=%s", llm_model, cwd)
         try:
             proc = subprocess.run(
                 ["git", "diff", "HEAD"],

--- a/jarvis-swift/Jarvis/AppDelegate.swift
+++ b/jarvis-swift/Jarvis/AppDelegate.swift
@@ -443,9 +443,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
     func expandHUD() {
         DispatchQueue.main.async {
-            // No-op when idle (nothing to restore). The reactor is the idle/standby state;
-            // the user activates Jarvis via hotkey or wake word, not by tapping the reactor.
-            guard self.lastVisibleState != .hidden else { return }
+            guard self.lastVisibleState != .hidden else {
+                // No prior conversation — open HUD with text input focused.
+                self.hudViewModel.state = .response(text: "")
+                self.hudWindow?.resizeForExpanded(toHeight: self.hudViewModel.contentHeight)
+                self.hudWindow?.orderFront(nil)
+                self.hudViewModel.focusTextInput = true
+                return
+            }
             self.hudViewModel.state = self.lastVisibleState
             self.hudWindow?.resizeForExpanded(toHeight: self.hudViewModel.contentHeight)
             self.hudWindow?.orderFront(nil)
@@ -455,11 +460,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     private func setupHUD() {
         let view = HUDView(
             viewModel: hudViewModel,
-            onDismiss:  { [weak self] in self?.hideHUD() },
-            onMinimize: { [weak self] in self?.minimizeHUD() },
-            onExpand:   { [weak self] in self?.expandHUD() },
-            onApprove:  { [weak self] in self?.handleApprove() },
-            onDeny:     { [weak self] in self?.handleDeny() }
+            onDismiss:     { [weak self] in self?.hideHUD() },
+            onMinimize:    { [weak self] in self?.minimizeHUD() },
+            onExpand:      { [weak self] in self?.expandHUD() },
+            onApprove:     { [weak self] in self?.handleApprove() },
+            onDeny:        { [weak self] in self?.handleDeny() },
+            onTextCommand: { [weak self] text in Task { @MainActor in self?.audioController.submitTextCommand(text: text) } }
         )
         let window = HUDWindow(viewModel: hudViewModel)
         let hostingView = TransparentHostingView(rootView: view)

--- a/jarvis-swift/Jarvis/AppDelegate.swift
+++ b/jarvis-swift/Jarvis/AppDelegate.swift
@@ -447,7 +447,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
                 // No prior conversation — open HUD with text input focused.
                 self.hudViewModel.state = .response(text: "")
                 self.hudWindow?.resizeForExpanded(toHeight: self.hudViewModel.contentHeight)
-                self.hudWindow?.orderFront(nil)
+                self.hudWindow?.makeKeyAndOrderFront(nil)
                 self.hudViewModel.focusTextInput = true
                 return
             }

--- a/jarvis-swift/Jarvis/AudioController.swift
+++ b/jarvis-swift/Jarvis/AudioController.swift
@@ -274,6 +274,8 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
 
             if shouldReissue, let text = originalCommand {
                 // Re-issue the original command — guardrails now trust the category for this session.
+                // lastInputWasText is intentionally inherited from the original command: a text-initiated
+                // command that triggers approval will re-issue silently (no TTS), a voice command will speak.
                 // Create a fresh turn for the re-issued command.
                 await MainActor.run { self.viewModel.startTurn(command: text) }
                 do {

--- a/jarvis-swift/Jarvis/AudioController.swift
+++ b/jarvis-swift/Jarvis/AudioController.swift
@@ -31,6 +31,7 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
     private var pendingApprovalCategory: String?
     private var lastCommandText: String?
     private var stepVoiceEnabled: Bool = false
+    private var lastInputWasText = false
 
     // MARK: - Init
 
@@ -200,6 +201,12 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
             return
         }
 
+        lastInputWasText = false
+        sendCommand(text: text)
+    }
+
+    func submitTextCommand(text: String) {
+        lastInputWasText = true
         sendCommand(text: text)
     }
 
@@ -234,7 +241,7 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
             let displayText = response.text.isEmpty ? fallback : response.text
             let speakText = response.speak ?? (response.text.isEmpty ? fallback : response.text)
             showHUD(.response(text: displayText))
-            speak(speakText)
+            if !lastInputWasText { speak(speakText) }
         }
     }
 

--- a/jarvis-swift/Jarvis/HUDView.swift
+++ b/jarvis-swift/Jarvis/HUDView.swift
@@ -279,16 +279,21 @@ struct HUDView: View {
         .task(id: inputFocused) {
             guard inputFocused else { cursorVisible = false; return }
             cursorVisible = true
-            while true {
-                try? await Task.sleep(for: .milliseconds(530))
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .milliseconds(530))
+                } catch {
+                    break
+                }
                 cursorVisible.toggle()
             }
+            cursorVisible = false
         }
         // One-shot focus trigger from ViewModel
         .onChange(of: viewModel.focusTextInput) { newValue in
             if newValue {
                 inputFocused = true
-                viewModel.focusTextInput = false
+                DispatchQueue.main.async { viewModel.focusTextInput = false }
             }
         }
     }

--- a/jarvis-swift/Jarvis/HUDView.swift
+++ b/jarvis-swift/Jarvis/HUDView.swift
@@ -245,32 +245,32 @@ struct HUDView: View {
                         .allowsHitTesting(false)
                 }
 
-                HStack(spacing: 2) {
-                    TextField("", text: $inputText)
-                        .font(.system(size: 12, design: .monospaced))
-                        .foregroundStyle(.white.opacity(0.85))
-                        .textFieldStyle(.plain)
-                        .focused($inputFocused)
-                        .disabled(isInputDisabled)
-                        .onSubmit {
-                            let trimmed = inputText.trimmingCharacters(in: .whitespaces)
-                            guard !trimmed.isEmpty else { return }
-                            inputText = ""
-                            onTextCommand(trimmed)
-                        }
-
-                    if inputFocused && inputText.isEmpty {
-                        Rectangle()
-                            .frame(width: 7, height: 13)
-                            .cornerRadius(1)
-                            .foregroundStyle(.white.opacity(cursorVisible ? 0.75 : 0))
-                    }
+                // Block cursor at leading edge — shown when focused and no text yet
+                if inputFocused && inputText.isEmpty {
+                    Rectangle()
+                        .frame(width: 7, height: 13)
+                        .clipShape(RoundedRectangle(cornerRadius: 1))
+                        .foregroundStyle(.white.opacity(cursorVisible ? 0.75 : 0))
+                        .allowsHitTesting(false)
                 }
+
+                TextField("", text: $inputText)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.85))
+                    .textFieldStyle(.plain)
+                    .focused($inputFocused)
+                    .disabled(isInputDisabled)
+                    .onSubmit {
+                        let trimmed = inputText.trimmingCharacters(in: .whitespaces)
+                        guard !trimmed.isEmpty else { return }
+                        inputText = ""
+                        onTextCommand(trimmed)
+                    }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 9)
+        .padding(.horizontal, 18)
+        .padding(.vertical, 11)
         .background(Color.black.opacity(0.12))
         .overlay(alignment: .top) {
             Color.white.opacity(0.06).frame(height: 1)

--- a/jarvis-swift/Jarvis/HUDView.swift
+++ b/jarvis-swift/Jarvis/HUDView.swift
@@ -18,12 +18,24 @@ struct HUDView: View {
     var onExpand:   () -> Void = {}
     var onApprove:  () -> Void = {}
     var onDeny:     () -> Void = {}
+    var onTextCommand: (String) -> Void = { _ in }
+
+    @State private var inputText   = ""
+    @State private var cursorVisible = false
+    @FocusState private var inputFocused: Bool
 
     @State private var isHovered = false
 
     private var maxThreadHeight: CGFloat {
         (NSScreen.main?.visibleFrame.height ?? 900) * 0.6 - 36 - 16
         // 36 = status bar, 16 = top/bottom padding
+    }
+
+    private var isInputDisabled: Bool {
+        switch viewModel.state {
+        case .listening, .thinking, .executing: return true
+        default: return false
+        }
     }
 
     var body: some View {
@@ -36,6 +48,7 @@ struct HUDView: View {
                     VStack(spacing: 0) {
                         threadView
                         statusBar
+                        inputRow
                     }
                     .frame(maxWidth: .infinity)
                     .background(
@@ -77,7 +90,17 @@ struct HUDView: View {
     @ViewBuilder
     private var threadView: some View {
         if viewModel.turns.isEmpty {
-            EmptyView()
+            Text("⌃⌥ for voice  ·  type below for text")
+                .font(.system(size: 11))
+                .foregroundStyle(.white.opacity(0.14))
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 14)
+                .background(
+                    GeometryReader { geo in
+                        Color.clear.preference(key: ThreadHeightKey.self, value: geo.size.height)
+                    }
+                )
         } else {
             ScrollViewReader { proxy in
                 ScrollView {
@@ -109,7 +132,7 @@ struct HUDView: View {
             }
             .onPreferenceChange(ThreadHeightKey.self) { height in
                 let cap = (NSScreen.main?.visibleFrame.height ?? 900) * 0.6
-                let newHeight = min(height + 36 + 16, cap)   // thread + status bar + padding
+                let newHeight = min(height + 36 + 36 + 16, cap)   // thread + status bar + input row + padding
                 // PreferenceKey callbacks may arrive off-main; guard before writing @Published.
                 DispatchQueue.main.async {
                     viewModel.contentHeight = max(newHeight, 120)
@@ -163,9 +186,15 @@ struct HUDView: View {
             }
 
         case .response:
-            Label("Done", systemImage: "checkmark")
-                .font(.system(size: 12))
-                .foregroundStyle(.white.opacity(0.4))
+            if viewModel.turns.isEmpty {
+                Text("⌃⌥ voice  ·  ↵ send")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white.opacity(0.18))
+            } else {
+                Label("Done", systemImage: "checkmark")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.white.opacity(0.4))
+            }
 
         case .approval(let description):
             HStack(spacing: 10) {
@@ -192,6 +221,75 @@ struct HUDView: View {
             Label("Denied", systemImage: "xmark.circle.fill")
                 .font(.system(size: 12))
                 .foregroundStyle(.red.opacity(0.8))
+        }
+    }
+
+    // MARK: - Text input
+
+    @ViewBuilder
+    private var inputRow: some View {
+        HStack(spacing: 6) {
+            Text("▶")
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(
+                    Color(red: 0.33, green: 0.67, blue: 1.0)
+                        .opacity(isInputDisabled ? 0.25 : 0.65)
+                )
+
+            ZStack(alignment: .leading) {
+                if inputText.isEmpty && !inputFocused {
+                    Text("ask me anything…")
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundStyle(.white.opacity(0.20))
+                        .italic()
+                        .allowsHitTesting(false)
+                }
+
+                HStack(spacing: 2) {
+                    TextField("", text: $inputText)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundStyle(.white.opacity(0.85))
+                        .textFieldStyle(.plain)
+                        .focused($inputFocused)
+                        .disabled(isInputDisabled)
+                        .onSubmit {
+                            let trimmed = inputText.trimmingCharacters(in: .whitespaces)
+                            guard !trimmed.isEmpty else { return }
+                            inputText = ""
+                            onTextCommand(trimmed)
+                        }
+
+                    if inputFocused && inputText.isEmpty {
+                        Rectangle()
+                            .frame(width: 7, height: 13)
+                            .cornerRadius(1)
+                            .foregroundStyle(.white.opacity(cursorVisible ? 0.75 : 0))
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 9)
+        .background(Color.black.opacity(0.12))
+        .overlay(alignment: .top) {
+            Color.white.opacity(0.06).frame(height: 1)
+        }
+        // Blink cursor while focused
+        .task(id: inputFocused) {
+            guard inputFocused else { cursorVisible = false; return }
+            cursorVisible = true
+            while true {
+                try? await Task.sleep(for: .milliseconds(530))
+                cursorVisible.toggle()
+            }
+        }
+        // One-shot focus trigger from ViewModel
+        .onChange(of: viewModel.focusTextInput) { newValue in
+            if newValue {
+                inputFocused = true
+                viewModel.focusTextInput = false
+            }
         }
     }
 }

--- a/jarvis-swift/Jarvis/HUDViewModel.swift
+++ b/jarvis-swift/Jarvis/HUDViewModel.swift
@@ -26,6 +26,9 @@ class HUDViewModel: ObservableObject {
     /// Capped at 60% of screen height. AppDelegate observes this to resize the window.
     @Published var contentHeight: CGFloat = 120
 
+    /// Set to true to focus the text input field. Resets itself to false after focus is applied (one-shot).
+    @Published var focusTextInput: Bool = false
+
     /// Start time of the current session (first command's timestamp). Used for save filename.
     private(set) var sessionStart: Date = Date()
 

--- a/jarvis-swift/Jarvis/HUDWindow.swift
+++ b/jarvis-swift/Jarvis/HUDWindow.swift
@@ -179,6 +179,17 @@ class HUDWindow: NSPanel {
         }
         super.mouseUp(with: event)   // Issue #8: maintain responder chain
     }
+
+    // Allow the panel to become key so text input receives keyboard events.
+    // Without this, .nonactivatingPanel prevents keyboard focus entirely.
+    override var canBecomeKey: Bool { true }
+
+    // Steal key status on click when expanded so the text field can receive input.
+    // This is intentional — clicking the HUD implies intent to interact with it.
+    override func mouseDown(with event: NSEvent) {
+        if !isMinimized { makeKey() }
+        super.mouseDown(with: event)
+    }
 }
 
 // MARK: - NSWindowDelegate


### PR DESCRIPTION
## Summary

- **Local-first for Planner and Reviewer**: Both now call `self.llm.respond()` instead of `self.llm.client.messages.create()` directly. When `local_model` is configured, Ollama is tried first; Claude is the fallback. Adds optional `system`/`tools` params to `respond()` across `BaseLLMClient`, `ClaudeClient`, `OllamaClient`, and `HybridClient` so each agent can supply its own custom prompt and tool set.

- **Plan persistence**: `coding_plan` now calls `save_plan()` after every plan is generated, saving to `~/.jarvis/coding-agent-plans/`. The plan file path is included in the return dict so callers can reference it.

- Uses a sentinel-exception pattern (`_PlanSubmitted`, `_ReviewSubmitted`) for the terminal tools (`submit_plan`, `submit_review`) so the loop can be interrupted cleanly inside `respond()` without modifying the loop itself.

## Test plan
- [ ] All 306 tests pass (`pytest`)
- [ ] `coding_plan` call saves a JSON file under `~/.jarvis/coding-agent-plans/`
- [ ] Plan file path appears in tool response
- [ ] With `local_model` configured, Ollama is attempted first for plan/review

🤖 Generated with [Claude Code](https://claude.com/claude-code)