### PR TITLE
Phase A: stabilize local-first foundation

### DIFF
--- a/jarvis-core/agent.py
+++ b/jarvis-core/agent.py
@@ -2,7 +2,9 @@ import anthropic
 import json
 import logging
 import os
+from dataclasses import dataclass, field
 from datetime import datetime
+import approval_store
 from guardrails import Action, Decision, Guardrails
 from tools.shell import ShellTool
 from tools.web import WebTool
@@ -440,6 +442,27 @@ def _is_milestone(tool_name: str, step_index: int) -> bool:
     return False
 
 
+@dataclass
+class _ClaudeLoopState:
+    """Mutable state for one agent run. Carried across a pause/resume so an
+    approved run continues instead of replaying from the original command."""
+    messages: list
+    tool_calls_made: list
+    steps: list
+    total_steps: int
+    last_tool_call: object
+    system_prompt: str
+    cwd: str | None
+    source: str
+    ollama_available: bool
+    command_id: str | None
+    user_text: str
+    # Resume point — set only while paused mid-turn.
+    pending_content: list | None = None
+    pending_index: int = 0
+    pending_results: list | None = None
+
+
 class Agent:
     def __init__(self, config: dict, guardrails: Guardrails, local_agent=None,
                  model: str = "claude-haiku-4-5-20251001"):
@@ -478,148 +501,190 @@ class Agent:
 
     def run(self, user_text: str, cwd: str | None = None, memory_context: str = "",
             history: list | None = None, ollama_available: bool = True,
-            source: str = "", step_callback=None) -> dict:
+            source: str = "", step_callback=None, command_id: str | None = None) -> dict:
         """Run the agent loop. cwd sets the active project directory for all tool calls.
-        Returns dict with speak, display, and optional approval_required."""
-        messages = [*(history or []), {"role": "user", "content": user_text}]
-        tool_calls_made = []
-        steps = []
-        system_prompt = self._build_system_prompt(cwd, memory_context, source)
+        Returns dict with speak, display, and optional approval_required. When command_id
+        is given and the run pauses for approval, a resume callable is registered so the
+        run can continue (server-side) without replaying earlier steps."""
+        state = _ClaudeLoopState(
+            messages=[*(history or []), {"role": "user", "content": user_text}],
+            tool_calls_made=[],
+            steps=[],
+            total_steps=0,
+            last_tool_call=None,
+            system_prompt=self._build_system_prompt(cwd, memory_context, source),
+            cwd=cwd,
+            source=source,
+            ollama_available=ollama_available,
+            command_id=command_id,
+            user_text=user_text,
+        )
+        return self._outer_loop(state, step_callback)
 
+    def resume(self, state: "_ClaudeLoopState", step_callback=None) -> dict:
+        """Continue a run paused for approval: finish the paused turn (execute the
+        now-approved tool and any remaining blocks), then run the outer loop."""
+        content = state.pending_content
+        start_idx = state.pending_index
+        tool_results = state.pending_results or []
+        state.pending_content = None
+        paused = self._process_turn(state, content, start_idx, tool_results, step_callback)
+        if paused is not None:
+            return paused  # paused again on a later block in the same turn
+        return self._outer_loop(state, step_callback)
+
+    def _outer_loop(self, state: "_ClaudeLoopState", step_callback) -> dict:
         max_steps = self._config.get("reasoning", {}).get("max_steps_claude", 5)
         max_total = self._config.get("reasoning", {}).get("max_total_steps", 20)
-        stall_detection = self._config.get("reasoning", {}).get("stall_detection", True)
-        total_steps = 0
-        last_tool_call = None  # (tool_name, frozenset(input.items())) for stall detection
 
         for _ in range(max_steps):
-            if total_steps >= max_total:
-                return {**format_response("I reached the maximum step limit.", tool_calls_made), "steps": steps}
+            if state.total_steps >= max_total:
+                return {**format_response("I reached the maximum step limit.", state.tool_calls_made), "steps": state.steps}
 
             # Omit delegate_to_local when Ollama is down to avoid wasting a step.
             # Omit notify for scheduled tasks — the scheduler fires the notification itself.
             available_tools = [
                 t for t in TOOL_DEFINITIONS
-                if (t["name"] != "delegate_to_local" or ollama_available)
-                and (t["name"] != "notify" or source != "scheduled")
+                if (t["name"] != "delegate_to_local" or state.ollama_available)
+                and (t["name"] != "notify" or state.source != "scheduled")
             ]
 
             response = self._client.messages.create(
                 model=self._model,
                 max_tokens=4096,
-                system=system_prompt,
+                system=state.system_prompt,
                 tools=available_tools,
-                messages=messages,
+                messages=state.messages,
             )
 
             if response.stop_reason in ("end_turn", "max_tokens"):
                 text = "".join(b.text for b in response.content if hasattr(b, "text"))
-                result = format_response(text, tool_calls_made)
-                result["steps"] = steps
+                result = format_response(text, state.tool_calls_made)
+                result["steps"] = state.steps
                 return result
 
-            messages.append({"role": "assistant", "content": response.content})
-            tool_results = []
-            stalled = False
+            state.messages.append({"role": "assistant", "content": response.content})
+            paused = self._process_turn(state, response.content, 0, [], step_callback)
+            if paused is not None:
+                return paused
 
-            for block in response.content:
-                if block.type != "tool_use":
-                    continue
+        return {**format_response("I ran out of steps. Please try again.", state.tool_calls_made), "steps": state.steps}
 
-                total_steps += 1
+    def _process_turn(self, state: "_ClaudeLoopState", content, start_idx: int,
+                      tool_results: list, step_callback) -> dict | None:
+        """Execute the tool_use blocks of one assistant turn from start_idx onward.
+        Returns an approval dict if it paused, else None (turn done, results appended).
+        On pause, all loop-state effects of the pending block are reverted so resume
+        re-processes it cleanly once the guardrail trusts the action."""
+        stall_detection = self._config.get("reasoning", {}).get("stall_detection", True)
+        stalled = False
 
-                # Stall detection: same tool + same input as the previous step. Once
-                # stalled, answer every remaining tool_use this turn with a warning
-                # tool_result instead of executing it. Leaving a tool_use unanswered
-                # would make the next messages.create() call invalid — the API requires
-                # every tool_use block to be paired with a tool_result.
-                if stall_detection and not stalled:
-                    try:
-                        current_call = (block.name, frozenset(block.input.items()))
-                    except TypeError:
-                        current_call = (block.name, block.name)
-                    if current_call == last_tool_call:
-                        stalled = True
-                    else:
-                        last_tool_call = current_call
+        for idx in range(start_idx, len(content)):
+            block = content[idx]
+            if block.type != "tool_use":
+                continue
 
-                if stalled:
-                    tool_results.append({
-                        "type": "tool_result",
-                        "tool_use_id": block.id,
-                        "content": "You already tried this exact action. Please try a different approach or conclude with what you know.",
-                    })
-                    continue
+            state.total_steps += 1
+            prev_last_tool_call = state.last_tool_call
 
-                step = {
-                    "tool": block.name,
-                    "input_summary": str(block.input)[:100],
-                    "milestone": _is_milestone(block.name, len(steps)),
-                    "result_summary": "",
-                }
-                steps.append(step)
-
-                if step_callback is not None:
-                    step_callback({
-                        "type": "step",
-                        "label": _step_label(block.name),
-                        "tool": block.name,
-                        "milestone": step["milestone"],
-                    })
-
+            # Stall detection: same tool + same input as the previous step. Once
+            # stalled, answer every remaining tool_use this turn with a warning
+            # tool_result instead of executing it (an unanswered tool_use is invalid).
+            if stall_detection and not stalled:
                 try:
-                    if block.name in SCHEDULE_TOOLS:
-                        if block.name == "create_schedule":
-                            if source == "scheduled":
-                                result = json.dumps({"error": "create_schedule is not allowed inside a scheduled task"})
-                            else:
-                                cron = block.input.get("cron")
-                                run_at = block.input.get("run_at_iso")
-                                timing = f"cron '{cron}'" if cron else f"at {run_at}"
-                                label = block.input.get("label", "")
-                                command = block.input.get("command", "")
-                                action = Action(
-                                    "schedule_create",
-                                    f"Schedule '{label}' to run '{command}' ({timing})",
-                                )
-                                if self._guardrails.classify(action) == Decision.REQUIRE_APPROVAL:
-                                    raise ApprovalRequiredError(
-                                        "create_schedule", action.description, "schedule_create"
-                                    )
-                                result = json.dumps(_handle_schedule_tool(block.name, block.input))
-                        else:
-                            result = json.dumps(_handle_schedule_tool(block.name, block.input))
-                    else:
-                        result = execute_tool(
-                            block.name, block.input,
-                            self._shell, self._web, self._code, self._macos,
-                            self._guardrails,
-                            default_cwd=cwd,
-                            local_agent=self._local_agent,
-                            coding=self._coding,
-                        )
-                    step["result_summary"] = result[:120] if isinstance(result, str) else str(result)[:120]
-                    tool_calls_made.append(block.name)
-                    tool_results.append({
-                        "type": "tool_result",
+                    current_call = (block.name, frozenset(block.input.items()))
+                except TypeError:
+                    current_call = (block.name, block.name)
+                if current_call == state.last_tool_call:
+                    stalled = True
+                else:
+                    state.last_tool_call = current_call
+
+            if stalled:
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": block.id,
+                    "content": "You already tried this exact action. Please try a different approach or conclude with what you know.",
+                })
+                continue
+
+            step = {
+                "tool": block.name,
+                "input_summary": str(block.input)[:100],
+                "milestone": _is_milestone(block.name, len(state.steps)),
+                "result_summary": "",
+            }
+            state.steps.append(step)
+
+            if step_callback is not None:
+                step_callback({
+                    "type": "step",
+                    "label": _step_label(block.name),
+                    "tool": block.name,
+                    "milestone": step["milestone"],
+                })
+
+            try:
+                if block.name in SCHEDULE_TOOLS:
+                    result = self._schedule_result(block, state.source)
+                else:
+                    result = execute_tool(
+                        block.name, block.input,
+                        self._shell, self._web, self._code, self._macos,
+                        self._guardrails,
+                        default_cwd=state.cwd,
+                        local_agent=self._local_agent,
+                        coding=self._coding,
+                    )
+                step["result_summary"] = result[:120] if isinstance(result, str) else str(result)[:120]
+                state.tool_calls_made.append(block.name)
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": block.id,
+                    "content": result,
+                })
+            except ApprovalRequiredError as e:
+                # Revert this block's loop-state effects so resume re-processes it as
+                # a fresh call (executes once the guardrail trusts the category).
+                state.steps.pop()
+                state.total_steps -= 1
+                state.last_tool_call = prev_last_tool_call
+                state.pending_content = content
+                state.pending_index = idx
+                state.pending_results = tool_results
+                if state.command_id:
+                    approval_store.register(
+                        state.command_id,
+                        lambda step_callback=None, _s=state: self.resume(_s, step_callback),
+                        {"user_text": state.user_text, "agent": "claude", "model": self._model},
+                    )
+                return {
+                    "speak": None,
+                    "display": None,
+                    "approval_required": {
+                        "tool": e.tool_name,
+                        "description": e.description,
                         "tool_use_id": block.id,
-                        "content": result,
-                    })
-                except ApprovalRequiredError as e:
-                    step["result_summary"] = "approval_required"
-                    return {
-                        "speak": None,
-                        "display": None,
-                        "approval_required": {
-                            "tool": e.tool_name,
-                            "description": e.description,
-                            "tool_use_id": block.id,
-                            "category": e.category,
-                        },
-                        "steps": steps,
-                    }
+                        "category": e.category,
+                    },
+                    "steps": state.steps,
+                }
 
-            if tool_results:
-                messages.append({"role": "user", "content": tool_results})
+        state.messages.append({"role": "user", "content": tool_results})
+        return None
 
-        return {**format_response("I ran out of steps. Please try again.", tool_calls_made), "steps": steps}
+    def _schedule_result(self, block, source: str) -> str:
+        """Run a schedule tool, raising ApprovalRequiredError if create_schedule is gated."""
+        if block.name == "create_schedule":
+            if source == "scheduled":
+                return json.dumps({"error": "create_schedule is not allowed inside a scheduled task"})
+            cron = block.input.get("cron")
+            run_at = block.input.get("run_at_iso")
+            timing = f"cron '{cron}'" if cron else f"at {run_at}"
+            label = block.input.get("label", "")
+            command = block.input.get("command", "")
+            action = Action("schedule_create", f"Schedule '{label}' to run '{command}' ({timing})")
+            if self._guardrails.classify(action) == Decision.REQUIRE_APPROVAL:
+                raise ApprovalRequiredError("create_schedule", action.description, "schedule_create")
+            return json.dumps(_handle_schedule_tool(block.name, block.input))
+        return json.dumps(_handle_schedule_tool(block.name, block.input))

--- a/jarvis-core/agent.py
+++ b/jarvis-core/agent.py
@@ -520,6 +520,7 @@ class Agent:
 
             messages.append({"role": "assistant", "content": response.content})
             tool_results = []
+            stalled = False
 
             for block in response.content:
                 if block.type != "tool_use":
@@ -527,19 +528,28 @@ class Agent:
 
                 total_steps += 1
 
-                # Stall detection: same tool + same input twice → inject warning
-                if stall_detection:
+                # Stall detection: same tool + same input as the previous step. Once
+                # stalled, answer every remaining tool_use this turn with a warning
+                # tool_result instead of executing it. Leaving a tool_use unanswered
+                # would make the next messages.create() call invalid — the API requires
+                # every tool_use block to be paired with a tool_result.
+                if stall_detection and not stalled:
                     try:
                         current_call = (block.name, frozenset(block.input.items()))
                     except TypeError:
                         current_call = (block.name, block.name)
                     if current_call == last_tool_call:
-                        messages.append({
-                            "role": "user",
-                            "content": "You already tried this exact action. Please try a different approach or conclude with what you know.",
-                        })
-                        break
-                    last_tool_call = current_call
+                        stalled = True
+                    else:
+                        last_tool_call = current_call
+
+                if stalled:
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": "You already tried this exact action. Please try a different approach or conclude with what you know.",
+                    })
+                    continue
 
                 step = {
                     "tool": block.name,

--- a/jarvis-core/approval_store.py
+++ b/jarvis-core/approval_store.py
@@ -1,0 +1,38 @@
+"""In-memory registry of paused agent runs awaiting approval.
+
+When an agent hits a guardrail it stops mid-run and registers a resume callable
+keyed by the command_id. On approval the server pops and invokes it, so the run
+continues from where it stopped (executing the approved tool, then onward) instead
+of replaying the whole command from the original text.
+
+In-memory only — paused runs do not survive a server restart, which is acceptable:
+approval happens seconds after the prompt, and a lost entry falls back to replay.
+"""
+
+from typing import Callable
+
+# command_id → {"resume": resume(step_callback) -> result dict, "meta": {...}}
+# meta carries what the router needs to annotate the resumed result and update
+# history: user_text, agent label, model name, intent_class.
+_PAUSED: dict[str, dict] = {}
+
+
+def register(command_id: str, resume_fn: Callable, meta: dict | None = None) -> None:
+    _PAUSED[command_id] = {"resume": resume_fn, "meta": meta or {}}
+
+
+def has(command_id: str) -> bool:
+    return command_id in _PAUSED
+
+
+def pop(command_id: str) -> dict | None:
+    return _PAUSED.pop(command_id, None)
+
+
+def discard(command_id: str) -> None:
+    """Drop a paused run without resuming (e.g. on denial)."""
+    _PAUSED.pop(command_id, None)
+
+
+def clear() -> None:
+    _PAUSED.clear()

--- a/jarvis-core/command_pipeline.py
+++ b/jarvis-core/command_pipeline.py
@@ -63,8 +63,11 @@ class CommandPipeline:
                     break
         self._registry[cmd.id] = cmd
 
-    def submit(self, text: str, cwd: str | None = None, source: str = "hotkey", step_callback=None) -> dict:
-        """Submit a command. Returns busy response if another command is executing."""
+    def submit(self, text: str, cwd: str | None = None, source: str = "hotkey",
+               step_callback=None, command_id: str | None = None) -> dict:
+        """Submit a command. Returns busy response if another command is executing.
+        command_id, when given, is the correlation id used to key a paused run so it
+        can be resumed after approval (see resume())."""
         if self._executing:
             return {"busy": True, "command_id": self._current_command_id}
 
@@ -91,7 +94,8 @@ class CommandPipeline:
 
         try:
             cmd.status = CommandStatus.ROUTING
-            result = self._router.process(text, cwd=cwd, memory_context=memory_context, source=source, step_callback=step_callback)
+            result = self._router.process(text, cwd=cwd, memory_context=memory_context, source=source,
+                                          step_callback=step_callback, command_id=command_id)
             cmd.status = CommandStatus.COMPLETED
             cmd.result = result
             cmd.completed_at = time.time()
@@ -100,6 +104,20 @@ class CommandPipeline:
             cmd.status = CommandStatus.FAILED
             cmd.completed_at = time.time()
             raise
+        finally:
+            self._executing = False
+            self._current_command_id = None
+
+    def resume(self, command_id: str, step_callback=None) -> dict | None:
+        """Continue a run paused for approval, under the single-command lock.
+        Returns the final result, None if there is no paused run (caller falls back
+        to replay), or a busy response if another command is executing."""
+        if self._executing:
+            return {"busy": True, "command_id": self._current_command_id}
+        self._executing = True
+        self._current_command_id = command_id
+        try:
+            return self._router.resume(command_id, step_callback=step_callback)
         finally:
             self._executing = False
             self._current_command_id = None

--- a/jarvis-core/command_pipeline.py
+++ b/jarvis-core/command_pipeline.py
@@ -78,14 +78,13 @@ class CommandPipeline:
         if self._memory and cwd:
             memory_context = self._memory.format_context(cwd)
             if not memory_context:
-                # Unknown project — trigger discovery (best-effort)
+                # Unknown project — trigger discovery (best-effort).
+                # Use the executor backend (capable local model), not the base host —
+                # discovery is an analysis task and must hit the server that's running.
                 try:
-                    ollama_cfg = self._router._config.get("ollama", {})
-                    self._memory.discover(
-                        cwd,
-                        ollama_host=ollama_cfg.get("host", "http://localhost:11434"),
-                        ollama_model=ollama_cfg.get("model", "mistral:latest"),
-                    )
+                    import config as cfg
+                    disc_host, disc_model = cfg.executor_backend(self._router._config)
+                    self._memory.discover(cwd, ollama_host=disc_host, ollama_model=disc_model)
                     memory_context = self._memory.format_context(cwd)
                 except Exception:
                     pass

--- a/jarvis-core/config.py
+++ b/jarvis-core/config.py
@@ -29,7 +29,6 @@ DEFAULTS = {
     "ollama": {
         "host": "http://localhost:11434",
         "model": "qwen35-opus-jarvis",
-        "classifier_model": "jarvis-classifier",
         "routing_mode": "local_first",   # local_first | haiku_first | ollama_first | claude_only | ollama_only
         "timeout_seconds": 300,
         "executor_host": "http://127.0.0.1:8090",

--- a/jarvis-core/config.py
+++ b/jarvis-core/config.py
@@ -110,3 +110,35 @@ def save(cfg: dict) -> None:
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     with open(CONFIG_PATH, "w") as f:
         json.dump(cfg, f, indent=2)
+
+
+# ── Backend resolution ────────────────────────────────────────────────────────
+# Single source of truth for which (host, model) each local role talks to. Before
+# this, the executor used ollama.executor_*, the router classifier used
+# ollama.classifier_*, but approval-classify and project-memory discovery read the
+# base ollama.host/model — so they hit the wrong server when the executor/classifier
+# ran on a separate MLX endpoint. All call sites now resolve through these helpers.
+
+def executor_backend(config: dict) -> tuple[str, str]:
+    """(host, model) for the local executor model. Prefers explicit executor_* keys,
+    falls back to the base ollama host/model."""
+    o = config.get("ollama", {})
+    host = o.get("executor_host") or o.get("host") or "http://localhost:11434"
+    model = o.get("executor_model") or o.get("model") or "mistral:latest"
+    return host, model
+
+
+def classifier_backend(config: dict) -> tuple[str, str]:
+    """(host, model) for the intent / approval classifier."""
+    o = config.get("ollama", {})
+    host = o.get("classifier_host") or o.get("host") or "http://localhost:11434"
+    model = o.get("classifier_model") or o.get("model") or "mistral:latest"
+    return host, model
+
+
+def embedder_backend(config: dict) -> tuple[str, str]:
+    """(host, model) for embeddings (coding-agent semantic index)."""
+    o = config.get("ollama", {})
+    host = o.get("embedder_host") or o.get("host") or "http://localhost:11434"
+    model = o.get("embedder_model") or "nomic-embed-text"
+    return host, model

--- a/jarvis-core/ollama_agent.py
+++ b/jarvis-core/ollama_agent.py
@@ -208,13 +208,13 @@ class OllamaAgent:
 
     @property
     def _host(self) -> str:
-        ollama = self._config.get("ollama", {})
-        return ollama.get("executor_host") or ollama.get("host", "http://localhost:11434")
+        import config as cfg
+        return cfg.executor_backend(self._config)[0]
 
     @property
     def _model(self) -> str:
-        ollama = self._config.get("ollama", {})
-        return ollama.get("executor_model") or ollama.get("model", "mistral:latest")
+        import config as cfg
+        return cfg.executor_backend(self._config)[1]
 
     @property
     def _chat_template_kwargs(self) -> dict | None:

--- a/jarvis-core/ollama_agent.py
+++ b/jarvis-core/ollama_agent.py
@@ -1,7 +1,9 @@
 import json
 import os
 import re
+from dataclasses import dataclass, field
 import httpx
+import approval_store
 from guardrails import Guardrails
 from tools.shell import ShellTool
 from tools.web import WebTool
@@ -180,6 +182,25 @@ def _stream_call(client: "httpx.Client", url: str, payload: dict,
         return choice["message"], choice.get("finish_reason")
 
 
+@dataclass
+class _OllamaLoopState:
+    """Mutable state for one Ollama run, carried across a pause/resume so an
+    approved run continues instead of replaying from the original command."""
+    messages: list
+    tool_calls_made: list
+    steps: list
+    max_steps: int
+    steps_used: int
+    last_tool_call: object
+    recent_tools: list
+    stall_detection: bool
+    cwd: str | None
+    command_id: str | None
+    user_text: str
+    pending_tool_calls: list | None = None
+    pending_index: int = 0
+
+
 class OllamaAgent:
     def __init__(self, config: dict, guardrails: Guardrails):
         self._config = config
@@ -228,147 +249,81 @@ class OllamaAgent:
     def _timeout(self) -> float:
         return float(self._config.get("ollama", {}).get("timeout_seconds", 300))
 
+    _WINDOW = 5
+    _NEAR_DUP_THRESHOLD = 3     # same tool ≥ 3 times in window → redundant
+
     def run(self, user_text: str, cwd: str | None = None, memory_context: str = "",
             history: list | None = None, step_callback=None,
-            intent_class: str | None = None) -> dict:
+            intent_class: str | None = None, command_id: str | None = None) -> dict:
         """Run Ollama tool-use loop. Raises EscalateToCloud if Ollama can't handle it.
-        Returns same dict shape as Agent.run()."""
+        Returns same dict shape as Agent.run(). When command_id is given and the run
+        pauses for approval, a resume callable is registered so it can continue
+        server-side without replaying earlier steps."""
         system_msg = _BASE_SYSTEM_PROMPT.format(home=os.path.expanduser("~")) + _OLLAMA_EXTRA
         if cwd:
             system_msg += f"\nActive project directory: {cwd}\n"
         if memory_context:
             system_msg += f"\nProject memory: {memory_context}\n"
 
-        messages = [
-            {"role": "system", "content": system_msg},
-            *(history or []),
-            {"role": "user", "content": user_text},
-        ]
-        tool_calls_made = []
-        steps = []
         budgets = self._config.get("reasoning", {}).get("step_budgets", {})
         if intent_class and intent_class in budgets:
             max_steps = int(budgets[intent_class])
         else:
             max_steps = int(self._config.get("reasoning", {}).get("max_steps_ollama", 10))
-        stall_detection = self._config.get("reasoning", {}).get("stall_detection", True)
-        last_tool_call = None        # (tool_name, args_key) for exact stall detection
-        recent_tools: list = []      # sliding window of last 5 tool names for near-duplicate detection
-        _WINDOW = 5
-        _NEAR_DUP_THRESHOLD = 3     # same tool ≥ 3 times in window → redundant
 
+        state = _OllamaLoopState(
+            messages=[
+                {"role": "system", "content": system_msg},
+                *(history or []),
+                {"role": "user", "content": user_text},
+            ],
+            tool_calls_made=[],
+            steps=[],
+            max_steps=max_steps,
+            steps_used=0,
+            last_tool_call=None,
+            recent_tools=[],
+            stall_detection=self._config.get("reasoning", {}).get("stall_detection", True),
+            cwd=cwd,
+            command_id=command_id,
+            user_text=user_text,
+        )
+        return self._outer_loop(state, step_callback)
+
+    def resume(self, state: "_OllamaLoopState", step_callback=None) -> dict:
+        """Continue a run paused for approval: finish the paused tool batch (execute
+        the now-approved tool and any remaining calls), then run the outer loop."""
+        tool_calls = state.pending_tool_calls
+        start_idx = state.pending_index
+        state.pending_tool_calls = None
+        kind, result = self._process_tools(state, tool_calls, start_idx, step_callback)
+        if kind in ("final", "paused"):
+            return result
+        return self._outer_loop(state, step_callback)
+
+    def _outer_loop(self, state: "_OllamaLoopState", step_callback) -> dict:
+        url = f"{self._host}/v1/chat/completions"
         try:
-            for step_idx in range(max_steps):
-                payload = {"model": self._model, "messages": messages, "tools": _OLLAMA_TOOLS}
+            while state.steps_used < state.max_steps:
+                state.steps_used += 1
+                payload = {"model": self._model, "messages": state.messages, "tools": _OLLAMA_TOOLS}
                 if self._chat_template_kwargs:
                     payload["chat_template_kwargs"] = self._chat_template_kwargs
 
-                msg, finish = _stream_call(
-                    self._http_client,
-                    f"{self._host}/v1/chat/completions",
-                    payload,
-                    step_callback,
-                )
+                msg, finish = _stream_call(self._http_client, url, payload, step_callback)
 
                 if finish == "stop" or not msg.get("tool_calls"):
                     text = _clean_ollama_text(msg.get("content") or "")
-                    if not text and not tool_calls_made and finish != "stop":
+                    if not text and not state.tool_calls_made and finish != "stop":
                         raise EscalateToCloud("Empty response from local executor — server may have crashed")
-                    result = format_response(text, tool_calls_made)
-                    result["steps"] = steps
+                    result = format_response(text, state.tool_calls_made)
+                    result["steps"] = state.steps
                     return result
 
-                # Append assistant message with tool calls
-                messages.append(msg)
-
-                for tc in msg["tool_calls"]:
-                    name = tc["function"]["name"]
-                    call_id = tc["id"]
-                    try:
-                        args = json.loads(tc["function"]["arguments"])
-                    except json.JSONDecodeError as e:
-                        messages.append({"role": "tool", "tool_call_id": call_id,
-                                         "content": f"error: malformed tool arguments — {e}. Please retry with valid JSON."})
-                        continue
-
-                    # finalize: model signals it has enough info — return immediately
-                    if name == "finalize":
-                        answer = args.get("answer", "") if isinstance(args, dict) else ""
-                        step = {"tool": "finalize", "input_summary": answer[:100],
-                                "result_summary": "finalized", "milestone": len(steps) == 0}
-                        steps.append(step)
-                        result = format_response(answer, tool_calls_made)
-                        result["steps"] = steps
-                        return result
-
-                    # Near-duplicate detection: same tool dominates recent window → salvage
-                    recent_tools.append(name)
-                    if len(recent_tools) > _WINDOW:
-                        recent_tools.pop(0)
-                    if stall_detection and recent_tools.count(name) >= _NEAR_DUP_THRESHOLD and steps:
-                        messages.append({
-                            "role": "user",
-                            "content": f"You have called '{name}' {recent_tools.count(name)} times with similar inputs and similar results. Stop and respond with what you already know.",
-                        })
-                        try:
-                            nr = self._http_client.post(
-                                f"{self._host}/v1/chat/completions",
-                                json={"model": self._model, "messages": messages, "tool_choice": "none"},
-                            )
-                            nr.raise_for_status()
-                            nr_text = _clean_ollama_text(nr.json()["choices"][0]["message"].get("content") or "")
-                            if nr_text:
-                                result = format_response(nr_text, tool_calls_made)
-                                result["steps"] = steps
-                                return result
-                        except Exception:
-                            pass
-
-                    # Exact stall detection: same tool + same args twice in a row → break
-                    if stall_detection:
-                        try:
-                            current_call = (name, frozenset(args.items()) if isinstance(args, dict) else str(args))
-                        except TypeError:
-                            current_call = (name, str(args))
-                        if current_call == last_tool_call:
-                            messages.append({
-                                "role": "user",
-                                "content": "You already tried this exact action. Please try a different approach or conclude with what you know.",
-                            })
-                            # Force one more completion without tools to get a response
-                            resp2 = self._http_client.post(
-                                f"{self._host}/v1/chat/completions",
-                                json={"model": self._model, "messages": messages},
-                            )
-                            resp2.raise_for_status()
-                            text = _clean_ollama_text(resp2.json()["choices"][0]["message"].get("content") or "")
-                            result = format_response(text, tool_calls_made)
-                            result["steps"] = steps
-                            return result
-                        last_tool_call = current_call
-
-                    step = {"tool": name, "input_summary": str(args)[:100], "result_summary": "", "milestone": len(steps) == 0}
-                    steps.append(step)
-                    if step_callback is not None:
-                        step_callback({"type": "step", "label": _step_label(name), "tool": name, "milestone": step["milestone"]})
-                    try:
-                        result = execute_tool(name, args, self._shell, self._web, self._code, self._macos, self._guardrails, default_cwd=cwd, coding=self._coding)
-                        step["result_summary"] = result[:120] if isinstance(result, str) else str(result)[:120]
-                        tool_calls_made.append(name)
-                    except ApprovalRequiredError as e:
-                        step["result_summary"] = "approval_required"
-                        return {
-                            "speak": None, "display": None,
-                            "approval_required": {
-                                "tool": e.tool_name,
-                                "description": e.description,
-                                "tool_use_id": call_id,
-                                "category": e.category,
-                            },
-                            "steps": steps,
-                        }
-
-                    messages.append({"role": "tool", "tool_call_id": call_id, "content": result})
+                state.messages.append(msg)
+                kind, result = self._process_tools(state, msg["tool_calls"], 0, step_callback)
+                if kind in ("final", "paused"):
+                    return result
 
         except httpx.ConnectError as e:
             raise EscalateToCloud(f"Ollama unavailable: {e}")
@@ -380,20 +335,131 @@ class OllamaAgent:
         # Salvage: one final no-tools call to emit whatever the model gathered
         try:
             salvage_resp = self._http_client.post(
-                f"{self._host}/v1/chat/completions",
-                json={"model": self._model, "messages": messages, "tool_choice": "none"},
+                url, json={"model": self._model, "messages": state.messages, "tool_choice": "none"},
             )
             salvage_resp.raise_for_status()
             salvage_text = _clean_ollama_text(
                 salvage_resp.json()["choices"][0]["message"].get("content") or ""
             )
             if salvage_text:
-                result = format_response(salvage_text, tool_calls_made)
-                result["steps"] = steps
+                result = format_response(salvage_text, state.tool_calls_made)
+                result["steps"] = state.steps
                 return result
         except Exception:
             pass
 
-        result = format_response("I ran out of steps. Please try again.", tool_calls_made)
-        result["steps"] = steps
+        result = format_response("I ran out of steps. Please try again.", state.tool_calls_made)
+        result["steps"] = state.steps
         return result
+
+    def _process_tools(self, state: "_OllamaLoopState", tool_calls: list, start_idx: int,
+                       step_callback) -> tuple[str, dict | None]:
+        """Process the tool calls of one assistant turn from start_idx. Returns
+        ("final", result) if it concluded, ("paused", approval) if it stopped for
+        approval, or ("continue", None) when the batch finished (continue the loop).
+        On pause, the pending call's loop-state effects are reverted so resume
+        re-processes it cleanly once the guardrail trusts the action."""
+        url = f"{self._host}/v1/chat/completions"
+        for j in range(start_idx, len(tool_calls)):
+            tc = tool_calls[j]
+            name = tc["function"]["name"]
+            call_id = tc["id"]
+            try:
+                args = json.loads(tc["function"]["arguments"])
+            except json.JSONDecodeError as e:
+                state.messages.append({"role": "tool", "tool_call_id": call_id,
+                                       "content": f"error: malformed tool arguments — {e}. Please retry with valid JSON."})
+                continue
+
+            # finalize: model signals it has enough info — return immediately
+            if name == "finalize":
+                answer = args.get("answer", "") if isinstance(args, dict) else ""
+                step = {"tool": "finalize", "input_summary": answer[:100],
+                        "result_summary": "finalized", "milestone": len(state.steps) == 0}
+                state.steps.append(step)
+                result = format_response(answer, state.tool_calls_made)
+                result["steps"] = state.steps
+                return ("final", result)
+
+            # Snapshot for clean revert if this call pauses for approval.
+            prev_last_tool_call = state.last_tool_call
+            recent_len = len(state.recent_tools)
+
+            # Near-duplicate detection: same tool dominates recent window → salvage
+            state.recent_tools.append(name)
+            if len(state.recent_tools) > self._WINDOW:
+                state.recent_tools.pop(0)
+            if state.stall_detection and state.recent_tools.count(name) >= self._NEAR_DUP_THRESHOLD and state.steps:
+                state.messages.append({
+                    "role": "user",
+                    "content": f"You have called '{name}' {state.recent_tools.count(name)} times with similar inputs and similar results. Stop and respond with what you already know.",
+                })
+                try:
+                    nr = self._http_client.post(
+                        url, json={"model": self._model, "messages": state.messages, "tool_choice": "none"},
+                    )
+                    nr.raise_for_status()
+                    nr_text = _clean_ollama_text(nr.json()["choices"][0]["message"].get("content") or "")
+                    if nr_text:
+                        result = format_response(nr_text, state.tool_calls_made)
+                        result["steps"] = state.steps
+                        return ("final", result)
+                except Exception:
+                    pass
+
+            # Exact stall detection: same tool + same args twice in a row → conclude
+            if state.stall_detection:
+                try:
+                    current_call = (name, frozenset(args.items()) if isinstance(args, dict) else str(args))
+                except TypeError:
+                    current_call = (name, str(args))
+                if current_call == state.last_tool_call:
+                    state.messages.append({
+                        "role": "user",
+                        "content": "You already tried this exact action. Please try a different approach or conclude with what you know.",
+                    })
+                    resp2 = self._http_client.post(
+                        url, json={"model": self._model, "messages": state.messages},
+                    )
+                    resp2.raise_for_status()
+                    text = _clean_ollama_text(resp2.json()["choices"][0]["message"].get("content") or "")
+                    result = format_response(text, state.tool_calls_made)
+                    result["steps"] = state.steps
+                    return ("final", result)
+                state.last_tool_call = current_call
+
+            step = {"tool": name, "input_summary": str(args)[:100], "result_summary": "", "milestone": len(state.steps) == 0}
+            state.steps.append(step)
+            if step_callback is not None:
+                step_callback({"type": "step", "label": _step_label(name), "tool": name, "milestone": step["milestone"]})
+            try:
+                result = execute_tool(name, args, self._shell, self._web, self._code, self._macos, self._guardrails, default_cwd=state.cwd, coding=self._coding)
+                step["result_summary"] = result[:120] if isinstance(result, str) else str(result)[:120]
+                state.tool_calls_made.append(name)
+            except ApprovalRequiredError as e:
+                # Revert this call's loop-state effects so resume re-processes it cleanly.
+                state.steps.pop()
+                state.last_tool_call = prev_last_tool_call
+                del state.recent_tools[recent_len:]
+                state.pending_tool_calls = tool_calls
+                state.pending_index = j
+                if state.command_id:
+                    approval_store.register(
+                        state.command_id,
+                        lambda step_callback=None, _s=state: self.resume(_s, step_callback),
+                        {"user_text": state.user_text, "agent": "ollama", "model": self._model},
+                    )
+                return ("paused", {
+                    "speak": None, "display": None,
+                    "approval_required": {
+                        "tool": e.tool_name,
+                        "description": e.description,
+                        "tool_use_id": call_id,
+                        "category": e.category,
+                    },
+                    "steps": state.steps,
+                })
+
+            state.messages.append({"role": "tool", "tool_call_id": call_id, "content": result})
+
+        return ("continue", None)

--- a/jarvis-core/router.py
+++ b/jarvis-core/router.py
@@ -112,8 +112,25 @@ class Router:
                 raise ValueError(f"No JSON object found in classifier response: {content!r}")
             return json.loads(content[start:end + 1])
 
+    def resume(self, command_id: str, step_callback=None) -> dict | None:
+        """Continue a run paused for approval. Returns the annotated final result,
+        or None if there is no paused run for this command_id (caller falls back to
+        replaying the original command)."""
+        import approval_store
+        entry = approval_store.pop(command_id)
+        if entry is None:
+            return None
+        start = time.time()
+        result = entry["resume"](step_callback)
+        meta = entry["meta"]
+        self._update_history(meta.get("user_text", ""), result)
+        return self._annotate(result, agent=meta.get("agent", "claude"),
+                              model=meta.get("model", ""), escalated=False,
+                              escalation_reason=None, intent_class=meta.get("intent_class"),
+                              start=start)
+
     def process(self, text: str, cwd: str | None = None, memory_context: str = "",
-                source: str = "", step_callback=None) -> dict:
+                source: str = "", step_callback=None, command_id: str | None = None) -> dict:
         """Route a command via pre-flight classifier and return response with metadata."""
         start = time.time()
         mode = self._routing_mode
@@ -136,7 +153,7 @@ class Router:
                           self._config.get("models", {}).get("haiku", "claude-haiku-4-5-20251001"))
 
             result = agent.run(text, cwd=cwd, memory_context=memory_context, history=self._history, source=source,
-                               step_callback=step_callback)
+                               step_callback=step_callback, command_id=command_id)
             self._update_history(text, result)
             return self._annotate(result, agent="claude", model=model_name,
                                   escalated=False, escalation_reason=classification.get("reason"),
@@ -155,7 +172,7 @@ class Router:
             intent_class = classification.get("intent_class", "read_only")
             if intent_class == "complex_reasoning":
                 result = self._sonnet.run(text, cwd=cwd, memory_context=memory_context, history=self._history,
-                                          source=source, step_callback=step_callback)
+                                          source=source, step_callback=step_callback, command_id=command_id)
                 self._update_history(text, result)
                 model_name = self._config.get("models", {}).get("sonnet", "claude-sonnet-4-6")
                 return self._annotate(result, agent="claude", model=model_name,
@@ -164,7 +181,7 @@ class Router:
 
             # Non-complex: use local OllamaAgent; escalate to Sonnet on failure
             try:
-                result = self._ollama.run(text, cwd=cwd, memory_context=memory_context, history=self._history, step_callback=step_callback, intent_class=intent_class)
+                result = self._ollama.run(text, cwd=cwd, memory_context=memory_context, history=self._history, step_callback=step_callback, intent_class=intent_class, command_id=command_id)
                 self._update_history(text, result)
                 executor_model = self._config.get("ollama", {}).get("executor_model") or self._ollama_model
                 return self._annotate(result, agent="ollama", model=executor_model,
@@ -175,7 +192,7 @@ class Router:
                     f"Local executor escalated to Sonnet: {e.reason}"
                 )
                 result = self._sonnet.run(text, cwd=cwd, memory_context=memory_context, history=self._history,
-                                          ollama_available=False, source=source, step_callback=step_callback)
+                                          ollama_available=False, source=source, step_callback=step_callback, command_id=command_id)
                 self._update_history(text, result)
                 model_name = self._config.get("models", {}).get("sonnet", "claude-sonnet-4-6")
                 return self._annotate(result, agent="claude", model=model_name,
@@ -185,7 +202,7 @@ class Router:
         # claude_only: skip classifier entirely
         if mode == "claude_only":
             result = self._claude.run(text, cwd=cwd, memory_context=memory_context, history=self._history, source=source,
-                                      step_callback=step_callback)
+                                      step_callback=step_callback, command_id=command_id)
             self._update_history(text, result)
             return self._annotate(result, agent="claude", model="claude-sonnet-4-6",
                                   escalated=False, escalation_reason=None,
@@ -206,7 +223,7 @@ class Router:
         escalation_reason = None
         if mode == "ollama_only" or can_handle_locally:
             try:
-                result = self._ollama.run(text, cwd=cwd, memory_context=memory_context, history=self._history, step_callback=step_callback, intent_class=intent_class)
+                result = self._ollama.run(text, cwd=cwd, memory_context=memory_context, history=self._history, step_callback=step_callback, intent_class=intent_class, command_id=command_id)
                 self._update_history(text, result)
                 return self._annotate(result, agent="ollama", model=self._ollama_model,
                                       escalated=False, escalation_reason=None,
@@ -228,7 +245,7 @@ class Router:
         # Pass ollama_available=False when escalated so Claude doesn't waste a step on delegate_to_local
         result = self._claude.run(text, cwd=cwd, memory_context=memory_context, history=self._history,
                                   ollama_available=(escalation_reason is None), source=source,
-                                  step_callback=step_callback)
+                                  step_callback=step_callback, command_id=command_id)
         self._update_history(text, result)
         return self._annotate(result, agent="claude", model="claude-sonnet-4-6",
                               escalated=escalation_reason is not None,

--- a/jarvis-core/router.py
+++ b/jarvis-core/router.py
@@ -73,13 +73,13 @@ class Router:
 
     @property
     def _classifier_model(self) -> str:
-        ollama_cfg = self._config.get("ollama", {})
-        return ollama_cfg.get("classifier_model", ollama_cfg.get("model", "mistral:latest"))
+        import config as cfg
+        return cfg.classifier_backend(self._config)[1]
 
     @property
     def _classifier_host(self) -> str:
-        ollama_cfg = self._config.get("ollama", {})
-        return ollama_cfg.get("classifier_host") or ollama_cfg.get("host", "http://localhost:11434")
+        import config as cfg
+        return cfg.classifier_backend(self._config)[0]
 
     @property
     def _ollama_host(self) -> str:

--- a/jarvis-core/server.py
+++ b/jarvis-core/server.py
@@ -373,8 +373,7 @@ class ClassifyRequest(BaseModel):
 def _classify_approval(text: str) -> bool | None:
     """Ask Ollama to classify text as approve/deny/unclear. Returns True/False/None."""
     config = cfg_module.load()
-    host = config.get("ollama", {}).get("host", "http://localhost:11434")
-    model = config.get("ollama", {}).get("model", "mistral:latest")
+    host, model = cfg_module.classifier_backend(config)
     system = (
         'You are a binary classifier. Reply with JSON only — no explanation.\n'
         'If the text means YES / APPROVE / ALLOW, reply: {"approved": true}\n'

--- a/jarvis-core/server.py
+++ b/jarvis-core/server.py
@@ -174,6 +174,7 @@ class ApprovalRequest(BaseModel):
     approved: bool
     trust_session: bool = False
     category: str = ""
+    command_id: str = ""
 
 
 @app.get("/health")
@@ -241,7 +242,7 @@ async def command(req: CommandRequest):
                 None,
                 lambda: _pipeline.submit(
                     req.text, cwd=req.cwd, source=req.source,
-                    step_callback=dispatcher.on_step
+                    step_callback=dispatcher.on_step, command_id=command_id
                 )
             )
         except _anthropic.RateLimitError:
@@ -280,7 +281,7 @@ async def command(req: CommandRequest):
                     None,
                     lambda: _pipeline.submit(
                         req.text, cwd=req.cwd, source=req.source,
-                        step_callback=dispatcher.on_step
+                        step_callback=dispatcher.on_step, command_id=command_id
                     )
                 )
                 _log_command(req, start, result)
@@ -372,15 +373,35 @@ def cancel_command(command_id: str):
 
 
 @app.post("/approve")
-def approve(req: ApprovalRequest):
+async def approve(req: ApprovalRequest):
+    import approval_store
+    if not req.approved:
+        approval_store.discard(req.command_id)
+        return {"acknowledged": True, "next_action": "cancelled"}
+
     if req.trust_session and req.category and _guardrails:
         _guardrails.trust_for_session(req.category)
-    # Approval is stateless — the client must re-issue the original /command request.
-    # next_action tells the client what to do after this response.
-    return {
-        "acknowledged": True,
-        "next_action": "reissue_command" if req.approved else "cancelled",
-    }
+
+    # If we still hold the paused run, resume it in place (execute the approved tool
+    # and continue) instead of having the client replay the whole command. Falls back
+    # to reissue_command when there is no paused state (e.g. after a server restart).
+    if req.command_id and approval_store.has(req.command_id):
+        loop = asyncio.get_running_loop()
+        try:
+            result = await loop.run_in_executor(None, lambda: _pipeline.resume(req.command_id))
+        except Exception:
+            logging.getLogger("jarvis.errors").exception("Resume after approval failed")
+            approval_store.discard(req.command_id)
+            return {"acknowledged": True, "next_action": "reissue_command"}
+        finally:
+            if _guardrails:
+                _guardrails.clear_session_trusts()
+        if result is None or result.get("busy"):
+            return {"acknowledged": True, "next_action": "reissue_command"}
+        return {"acknowledged": True, "next_action": "resumed", **result}
+
+    # No paused state — client re-issues the original command (category now trusted).
+    return {"acknowledged": True, "next_action": "reissue_command"}
 
 
 class ClassifyRequest(BaseModel):

--- a/jarvis-core/server.py
+++ b/jarvis-core/server.py
@@ -140,6 +140,23 @@ async def _deferred_bot_start():
 
 app = FastAPI(lifespan=lifespan)
 
+# Shared-secret auth between the Swift app and this local server. The Swift app
+# generates a token at launch and passes it to this process via JARVIS_AUTH_TOKEN,
+# then sends it as the X-Jarvis-Token header. Without this, any local process could
+# POST /command and get arbitrary shell execution. Enforced only when the token is
+# set — a manually-run dev server (or the test client) stays open.
+_AUTH_TOKEN = os.environ.get("JARVIS_AUTH_TOKEN", "")
+_AUTH_EXEMPT_PATHS = {"/health"}
+
+
+@app.middleware("http")
+async def _auth_middleware(request, call_next):
+    if _AUTH_TOKEN and request.url.path not in _AUTH_EXEMPT_PATHS:
+        if request.headers.get("X-Jarvis-Token") != _AUTH_TOKEN:
+            from fastapi.responses import JSONResponse
+            return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+    return await call_next(request)
+
 
 class CommandRequest(BaseModel):
     text: str

--- a/jarvis-core/tests/test_agent.py
+++ b/jarvis-core/tests/test_agent.py
@@ -125,6 +125,41 @@ def test_execute_tool_run_code_multi_language():
     mock_run.assert_called_once_with('console.log("hi")', "javascript", cwd=None)
 
 
+def test_code_guardrail_category_detects_deletions():
+    from tools._dispatch import _code_guardrail_category
+    assert _code_guardrail_category("import shutil; shutil.rmtree('x')") == "delete_files"
+    assert _code_guardrail_category("os.unlink('a')") == "delete_files"
+    assert _code_guardrail_category("fs.rmSync('a')") == "delete_files"
+    assert _code_guardrail_category("from pathlib import Path; Path('x').unlink()") == "delete_files"
+    assert _code_guardrail_category("print('hello')") == "run_code_with_effects"
+
+
+def test_shell_guardrail_category_extra_destructive():
+    from tools._dispatch import _shell_guardrail_category
+    assert _shell_guardrail_category("find . -name '*.log' -delete") == "delete_files"
+    assert _shell_guardrail_category("git clean -fd") == "delete_files"
+    assert _shell_guardrail_category("shred -u secret.txt") == "delete_files"
+    assert _shell_guardrail_category("ls -la") == "run_shell"
+
+
+def test_run_code_deletion_requires_approval():
+    """run_code that deletes files routes to delete_files (require_approval),
+    closing the gap where os.remove bypassed the gate that blocks shell 'rm'."""
+    from tools._errors import ApprovalRequiredError
+    agent = make_agent()
+    with pytest.raises(ApprovalRequiredError):
+        execute_tool("run_code", {"code": "import os; os.remove('/tmp/x')", "language": "python"},
+                     agent._shell, agent._web, agent._code, agent._macos, agent._guardrails, default_cwd=None)
+
+
+def test_run_code_pure_computation_auto_allowed():
+    agent = make_agent()
+    with patch.object(agent._code, "run_snippet", return_value={"exit_code": 0, "stdout": "4", "stderr": "", "error": None}):
+        result = execute_tool("run_code", {"code": "print(2+2)", "language": "python"},
+                              agent._shell, agent._web, agent._code, agent._macos, agent._guardrails, default_cwd=None)
+    assert "stdout=4" in result
+
+
 def test_approval_required_returns_structured_response():
     agent = make_agent()
     mock_block = MagicMock()
@@ -270,14 +305,41 @@ def test_stall_detection_injects_warning(tmp_path, monkeypatch):
          patch("tools._dispatch.execute_tool", return_value="exit_code=0\nstdout=tmp\nstderr="):
         agent.run("do something")
 
-    # Check that a stall warning was injected somewhere in the messages
+    # The stall warning is delivered as a tool_result (so the tool_use/tool_result
+    # pairing stays valid for the Anthropic API), not as a bare user text message.
     all_messages = [msg for call in call_log for msg in call]
-    stall_msg = next(
-        (m for m in all_messages
-         if isinstance(m.get("content"), str) and "already tried" in m["content"].lower()),
-        None
+    warning_found = any(
+        isinstance(m.get("content"), list)
+        and any(
+            isinstance(b, dict)
+            and b.get("type") == "tool_result"
+            and "already tried" in str(b.get("content", "")).lower()
+            for b in m["content"]
+        )
+        for m in all_messages
     )
-    assert stall_msg is not None
+    assert warning_found, "stall warning should be delivered via a tool_result"
+
+    # API invariant: every assistant tool_use must be answered by a tool_result in the
+    # immediately following user message — an unanswered tool_use 400s the next call.
+    for messages in call_log:
+        for i, m in enumerate(messages):
+            content = m.get("content")
+            if m.get("role") != "assistant" or not isinstance(content, list):
+                continue
+            tool_use_ids = [getattr(b, "id", None) for b in content
+                            if getattr(b, "type", None) == "tool_use"]
+            if not tool_use_ids:
+                continue
+            assert i + 1 < len(messages), "tool_use not followed by any message"
+            nxt = messages[i + 1]
+            assert nxt.get("role") == "user"
+            results = nxt.get("content")
+            assert isinstance(results, list)
+            result_ids = [r.get("tool_use_id") for r in results
+                          if isinstance(r, dict) and r.get("type") == "tool_result"]
+            for tid in tool_use_ids:
+                assert tid in result_ids, f"tool_use {tid} has no tool_result"
 
 
 def test_run_returns_steps_list(tmp_path, monkeypatch):

--- a/jarvis-core/tests/test_agent.py
+++ b/jarvis-core/tests/test_agent.py
@@ -125,6 +125,62 @@ def test_execute_tool_run_code_multi_language():
     mock_run.assert_called_once_with('console.log("hi")', "javascript", cwd=None)
 
 
+def test_resume_continues_without_replaying_prior_steps():
+    """A run paused for approval resumes by executing the approved tool and
+    continuing — it must NOT replay the safe steps that ran before the pause."""
+    import approval_store
+    from guardrails import Guardrails
+    approval_store.clear()
+
+    config = {
+        "anthropic_api_key": "sk-test",
+        "guardrails": {"run_shell": "auto_allow", "delete_files": "require_approval"},
+    }
+    guardrails = Guardrails(config)
+    agent = Agent(config=config, guardrails=guardrails)
+
+    def block(name, inp, bid):
+        b = MagicMock(); b.type = "tool_use"; b.name = name; b.input = inp; b.id = bid
+        return b
+
+    responses = []
+    # turn 1: safe ls (auto-allow) → executes
+    r1 = MagicMock(); r1.stop_reason = "tool_use"; r1.content = [block("shell_run", {"command": "ls /tmp"}, "t1")]
+    # turn 2: rm (delete_files → require_approval) → pause
+    r2 = MagicMock(); r2.stop_reason = "tool_use"; r2.content = [block("shell_run", {"command": "rm /tmp/foo"}, "t2")]
+    # turn 3 (only reached after resume): done
+    r3 = MagicMock(); r3.stop_reason = "end_turn"; tb = MagicMock(); tb.text = "Done.\nVOICE: Removed it."; r3.content = [tb]
+    responses = [r1, r2, r3]
+    create_calls = {"n": 0}
+
+    def fake_create(**kwargs):
+        i = create_calls["n"]; create_calls["n"] += 1
+        return responses[i]
+
+    shell = MagicMock(return_value={"exit_code": 0, "stdout": "", "stderr": "", "error": None})
+    with patch.object(agent._client.messages, "create", side_effect=fake_create), \
+         patch.object(agent._shell, "run", shell):
+        first = agent.run("clean up /tmp/foo", command_id="cmd1")
+        # Paused on the rm; only the ls has run so far.
+        assert "approval_required" in first
+        assert first["approval_required"]["category"] == "delete_files"
+        assert approval_store.has("cmd1")
+        assert shell.call_count == 1
+
+        # Approve: trust the category, then resume.
+        guardrails.trust_for_session("delete_files")
+        entry = approval_store.pop("cmd1")
+        assert entry is not None
+        assert entry["meta"]["agent"] == "claude"
+        final = entry["resume"]()
+
+    assert final["speak"] == "Removed it."
+    # ls + rm == 2 shell calls. If the run had replayed, ls would run twice (3 total).
+    assert shell.call_count == 2
+    # Exactly 3 model turns: the original two plus one after resume (no replay turns).
+    assert create_calls["n"] == 3
+
+
 def test_code_guardrail_category_detects_deletions():
     from tools._dispatch import _code_guardrail_category
     assert _code_guardrail_category("import shutil; shutil.rmtree('x')") == "delete_files"

--- a/jarvis-core/tests/test_command_pipeline.py
+++ b/jarvis-core/tests/test_command_pipeline.py
@@ -39,7 +39,7 @@ def test_submit_returns_result_with_command_id(pipeline, mock_router):
 
 def test_submit_calls_router_with_text_and_cwd(pipeline, mock_router):
     pipeline.submit("list files", cwd="/my/project", source="hotkey")
-    mock_router.process.assert_called_once_with("list files", cwd="/my/project", memory_context="", source="hotkey", step_callback=None)
+    mock_router.process.assert_called_once_with("list files", cwd="/my/project", memory_context="", source="hotkey", step_callback=None, command_id=None)
 
 
 def test_submit_marks_command_completed(pipeline):

--- a/jarvis-core/tests/test_config.py
+++ b/jarvis-core/tests/test_config.py
@@ -5,6 +5,33 @@ from unittest.mock import patch
 import config
 
 
+def test_executor_backend_prefers_executor_keys():
+    cfg = {"ollama": {"host": "http://base:11434", "model": "base",
+                      "executor_host": "http://exec:8090", "executor_model": "exec-model"}}
+    assert config.executor_backend(cfg) == ("http://exec:8090", "exec-model")
+
+
+def test_executor_backend_falls_back_to_base():
+    cfg = {"ollama": {"host": "http://base:11434", "model": "base"}}
+    assert config.executor_backend(cfg) == ("http://base:11434", "base")
+
+
+def test_classifier_backend_prefers_classifier_keys():
+    cfg = {"ollama": {"host": "http://base:11434", "model": "base",
+                      "classifier_host": "http://cls:8090", "classifier_model": "cls-model"}}
+    assert config.classifier_backend(cfg) == ("http://cls:8090", "cls-model")
+
+
+def test_classifier_backend_falls_back_to_base():
+    cfg = {"ollama": {"host": "http://base:11434", "model": "base"}}
+    assert config.classifier_backend(cfg) == ("http://base:11434", "base")
+
+
+def test_embedder_backend_defaults_to_nomic():
+    cfg = {"ollama": {"host": "http://base:11434"}}
+    assert config.embedder_backend(cfg) == ("http://base:11434", "nomic-embed-text")
+
+
 def test_config_creates_default_file(tmp_path):
     config_path = tmp_path / "config.json"
     with patch("config.CONFIG_PATH", config_path):

--- a/jarvis-core/tests/test_router.py
+++ b/jarvis-core/tests/test_router.py
@@ -250,7 +250,7 @@ def test_haiku_first_uses_sonnet_for_complex_reasoning(haiku_router, mock_haiku_
     assert result["_model"] == "claude-sonnet-4-6"
 
 
-def test_haiku_first_is_default_routing_mode(config):
+def test_config_fixture_default_routing_mode_is_local_first(config):
     assert config["ollama"]["routing_mode"] == "local_first"
 
 

--- a/jarvis-core/tests/test_router.py
+++ b/jarvis-core/tests/test_router.py
@@ -362,6 +362,27 @@ def test_default_routing_mode_is_local_first():
     assert DEFAULTS["ollama"]["routing_mode"] == "local_first"
 
 
+def test_resume_returns_none_when_no_paused_run(haiku_router):
+    import approval_store
+    approval_store.clear()
+    assert haiku_router.resume("nope") is None
+
+
+def test_resume_invokes_stored_resumer_and_annotates(haiku_router):
+    import approval_store
+    approval_store.clear()
+    approval_store.register(
+        "c1",
+        lambda step_callback=None: {"speak": "ok", "display": "ok", "steps": []},
+        {"user_text": "hi", "agent": "ollama", "model": "m1"},
+    )
+    result = haiku_router.resume("c1")
+    assert result["_agent"] == "ollama"
+    assert result["_model"] == "m1"
+    assert result["speak"] == "ok"
+    assert not approval_store.has("c1")  # popped
+
+
 def test_default_executor_model_is_qwen35_opus_jarvis():
     """Default ollama executor model should be qwen35-opus-jarvis."""
     from config import DEFAULTS

--- a/jarvis-core/tests/test_server.py
+++ b/jarvis-core/tests/test_server.py
@@ -35,6 +35,29 @@ def test_health_endpoint(client_and_agent):
     assert response.json()["status"] == "ok"
 
 
+def test_auth_disabled_when_token_unset(client_and_agent, monkeypatch):
+    monkeypatch.setattr("server._AUTH_TOKEN", "")
+    client, _, _ = client_and_agent
+    assert client.post("/command", json={"text": "hi", "source": "telegram"}).status_code == 200
+
+
+def test_auth_rejects_missing_or_wrong_token(client_and_agent, monkeypatch):
+    monkeypatch.setattr("server._AUTH_TOKEN", "secret")
+    client, _, _ = client_and_agent
+    assert client.post("/command", json={"text": "hi", "source": "telegram"}).status_code == 401
+    assert client.post("/command", json={"text": "hi", "source": "telegram"},
+                       headers={"X-Jarvis-Token": "nope"}).status_code == 401
+
+
+def test_auth_accepts_valid_token_and_exempts_health(client_and_agent, monkeypatch):
+    monkeypatch.setattr("server._AUTH_TOKEN", "secret")
+    client, _, _ = client_and_agent
+    assert client.get("/health").status_code == 200  # exempt
+    ok = client.post("/command", json={"text": "hi", "source": "telegram"},
+                     headers={"X-Jarvis-Token": "secret"})
+    assert ok.status_code == 200
+
+
 def test_command_endpoint_returns_speak_and_display(client_and_agent):
     # Telegram (blocking path) returns speak/display in HTTP response.
     client, _, _ = client_and_agent

--- a/jarvis-core/tests/test_server.py
+++ b/jarvis-core/tests/test_server.py
@@ -72,14 +72,54 @@ def test_command_endpoint_calls_agent_with_cwd(client_and_agent):
     from unittest.mock import ANY
     client, mock_router, _ = client_and_agent
     client.post("/command", json={"text": "open safari", "cwd": "/my/project"})
-    mock_router.process.assert_called_once_with("open safari", cwd="/my/project", memory_context="", source="hotkey", step_callback=ANY)
+    mock_router.process.assert_called_once_with("open safari", cwd="/my/project", memory_context="", source="hotkey", step_callback=ANY, command_id=ANY)
 
 
 def test_command_endpoint_cwd_defaults_to_none(client_and_agent):
     from unittest.mock import ANY
     client, mock_router, _ = client_and_agent
     client.post("/command", json={"text": "hello"})
-    mock_router.process.assert_called_once_with("hello", cwd=None, memory_context="", source="hotkey", step_callback=ANY)
+    mock_router.process.assert_called_once_with("hello", cwd=None, memory_context="", source="hotkey", step_callback=ANY, command_id=ANY)
+
+
+def test_approve_resumes_paused_run(client_and_agent):
+    import approval_store
+    approval_store.clear()
+    client, mock_router, mock_guardrails = client_and_agent
+    approval_store.register("cmd-x", lambda step_callback=None: {},
+                            {"user_text": "x", "agent": "claude", "model": "m"})
+    mock_router.resume.return_value = {"speak": "done", "display": "done", "steps": []}
+    resp = client.post("/approve", json={
+        "tool_use_id": "t", "approved": True, "command_id": "cmd-x",
+        "trust_session": True, "category": "delete_files",
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["next_action"] == "resumed"
+    assert data["speak"] == "done"
+    mock_guardrails.trust_for_session.assert_called_with("delete_files")
+    approval_store.clear()
+
+
+def test_approve_denied_discards_paused_run(client_and_agent):
+    import approval_store
+    approval_store.clear()
+    client, _, _ = client_and_agent
+    approval_store.register("cmd-y", lambda step_callback=None: {}, {})
+    resp = client.post("/approve", json={"tool_use_id": "t", "approved": False, "command_id": "cmd-y"})
+    assert resp.json()["next_action"] == "cancelled"
+    assert not approval_store.has("cmd-y")
+
+
+def test_approve_without_paused_state_falls_back_to_reissue(client_and_agent):
+    import approval_store
+    approval_store.clear()
+    client, _, _ = client_and_agent
+    resp = client.post("/approve", json={
+        "tool_use_id": "t", "approved": True, "command_id": "missing",
+        "trust_session": True, "category": "delete_files",
+    })
+    assert resp.json()["next_action"] == "reissue_command"
 
 
 def test_approve_endpoint_trusts_session(client_and_agent):
@@ -256,7 +296,7 @@ def test_empty_cwd_string_normalized_to_none(client_and_agent):
     from unittest.mock import ANY
     client, mock_router, _ = client_and_agent
     client.post("/command", json={"text": "hello", "cwd": ""})
-    mock_router.process.assert_called_once_with("hello", cwd=None, memory_context="", source="hotkey", step_callback=ANY)
+    mock_router.process.assert_called_once_with("hello", cwd=None, memory_context="", source="hotkey", step_callback=ANY, command_id=ANY)
 
 
 def test_get_config_redacts_api_keys(client_and_agent, tmp_path):

--- a/jarvis-core/tests/test_tools_web.py
+++ b/jarvis-core/tests/test_tools_web.py
@@ -19,6 +19,7 @@ def test_search_returns_results_with_content():
     assert len(results) > 0
     assert results[0]["title"] == "Example Title"
     assert results[0]["url"] == "https://example.com"
+    assert results[0]["snippet"] == "Example snippet text"
 
 
 def test_search_handles_network_error():

--- a/jarvis-core/tools/_dispatch.py
+++ b/jarvis-core/tools/_dispatch.py
@@ -9,9 +9,25 @@ from tools._errors import ApprovalRequiredError
 # Shell commands that modify the filesystem (create/move/copy/permission changes)
 # These are routed to "modify_filesystem" (require_approval) instead of "run_shell" (auto_allow).
 _FS_MODIFY_RE = re.compile(r'\b(mkdir|touch|cp|mv|ln|chmod|chown|chgrp|rsync|install)\b')
-# rm/rmdir already map to delete_files via TOOL_TO_GUARDRAIL_CATEGORY for file tools,
-# but also catch them here for shell_run commands
-_FS_DELETE_RE = re.compile(r'\b(rm|rmdir)\b')
+# Destructive shell commands → "delete_files" (require_approval). Covers explicit
+# removal plus less-obvious destroyers: find -delete, git clean, shred, dd.
+_FS_DELETE_RE = re.compile(
+    r'\b(rm|rmdir|shred)\b'      # explicit removal
+    r'|\bfind\b.*-delete\b'      # find ... -delete
+    r'|\bgit\s+clean\b'          # git clean removes untracked files
+    r'|\bdd\b'                   # dd can overwrite disks/files
+)
+# run_code snippets that delete files. Gated like a destructive shell command so a
+# Python/JS snippet can't delete files under the auto-allowed run_code path while
+# shell "rm" requires approval. (File *writes* stay auto-allowed — parity with file_write.)
+_CODE_DELETE_RE = re.compile(
+    r'os\.(remove|unlink|rmdir|removedirs)\b'
+    r'|shutil\.rmtree\b'
+    r'|\.unlink\('                                          # Path(...).unlink()
+    r'|fs\.(unlink|rm|rmdir|rmSync|rmdirSync|unlinkSync)\b'  # node fs
+    r'|File\.(delete|unlink)\b|FileUtils\.rm\b'             # ruby
+    r'|\brm\s+-[rf]|\bshred\b'                              # shelling out from code
+)
 
 
 def _shell_guardrail_category(command: str) -> str:
@@ -21,6 +37,14 @@ def _shell_guardrail_category(command: str) -> str:
     if _FS_MODIFY_RE.search(command):
         return "modify_filesystem"
     return "run_shell"
+
+
+def _code_guardrail_category(code: str) -> str:
+    """Return the guardrail category for a run_code snippet. Deletion-capable code
+    is gated as delete_files; everything else is auto-allowed under run_code_with_effects."""
+    if _CODE_DELETE_RE.search(code):
+        return "delete_files"
+    return "run_code_with_effects"
 
 # Timeout for delegated Claude Code tasks (complex codebase work can take a while)
 _CLAUDE_CODE_TIMEOUT = 300
@@ -66,6 +90,8 @@ def execute_tool(
     """Dispatch a tool call. Raises ApprovalRequiredError if guardrails block it."""
     if tool_name == "shell_run":
         category = _shell_guardrail_category(tool_input.get("command", ""))
+    elif tool_name == "run_code":
+        category = _code_guardrail_category(tool_input.get("code", ""))
     else:
         category = TOOL_TO_GUARDRAIL_CATEGORY.get(tool_name, "run_shell")
     description = f"{tool_name}: {tool_input}"

--- a/jarvis-core/tools/web.py
+++ b/jarvis-core/tools/web.py
@@ -33,7 +33,7 @@ class WebTool:
         results = []
         for title_el in soup.select(".result__title")[:num_results]:
             link = title_el.find("a")
-            snippet_el = title_el.find_next(".result__snippet")
+            snippet_el = title_el.find_next(class_="result__snippet")
             results.append({
                 "title": link.get_text(strip=True) if link else "",
                 "url": link.get("href", "") if link else "",

--- a/jarvis-swift/Jarvis.xcodeproj/project.pbxproj
+++ b/jarvis-swift/Jarvis.xcodeproj/project.pbxproj
@@ -7,41 +7,42 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1A2B3C4D5E6F7A8B9C0D1E2F /* ArcReactorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3C4D5E6F7A8B9C0D1E2F3A /* ArcReactorView.swift */; };
+		20D2689B00846AD289147615 /* ConversationTurn.swift in Sources */ = {isa = PBXBuildFile; fileRef = D722C25A1AB2A313C61C2A2F /* ConversationTurn.swift */; };
+		2A61E147BF98A57F2E45B368 /* ServerAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F2E672EFF61B016C7F5B5B /* ServerAuth.swift */; };
+		38949C6A1B97F9254C8BF611 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1DA8E26A20181D485520F5D /* SettingsView.swift */; };
 		4C532BB72DB8492A9CA01EFA /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFDE0C2B9C763CB14D4860EF /* MenuBarController.swift */; };
+		50B5984098E2CA321B052F50 /* ArcReactorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF2A2306408B895EC1588A19 /* ArcReactorView.swift */; };
+		5B192FF0418EF35BCAB45133 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DE1934410CC3348DF27C92 /* SettingsViewModel.swift */; };
 		5E25349CC3262A18DE554A01 /* JarvisApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD65447B9E4C38A85B4132FD /* JarvisApp.swift */; };
 		67C0FA63859E57CDAD3386B0 /* HUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827BD974D1EDA53447ABD677 /* HUDView.swift */; };
+		73EB57CE388694AD14C8846D /* ConversationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28050F6CD9B2DCFF2B910307 /* ConversationStore.swift */; };
 		80196255C1F1E1FAD02CF1B6 /* HUDWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54CCBC142B08F40AAF2803FF /* HUDWindow.swift */; };
+		9A4605C19C8DED53DB7CFDA9 /* JarvisClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1782D973C548CA02194D931A /* JarvisClient.swift */; };
 		9DC43759D0969F2E2310C9B0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF188A9690C132DC1EAA28DE /* AppDelegate.swift */; };
-		A1B2C3D4E5F6A7B8C9D0E1F2 /* JarvisClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F3 /* JarvisClient.swift */; };
-		B2C3D4E5F6A7B8C9D0E1F2A3 /* AudioController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A4 /* AudioController.swift */; };
+		C5A0B5A7794EDAD1DAD54D45 /* AudioController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE46948996AFC7C505BF9F2D /* AudioController.swift */; };
 		F661D252F7E4C5019639C9E1 /* HUDViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14F409752942B73285CEBFE /* HUDViewModel.swift */; };
-		C3D4E5F6A7B8C9D0E1F2A3B4 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D4E5F6A7B8C9D0E1F2A3B5 /* SettingsViewModel.swift */; };
-		C3D4E5F6A7B8C9D0E1F2A3C4 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D4E5F6A7B8C9D0E1F2A3C5 /* SettingsView.swift */; };
-		C3D4E5F6A7B8C9D0E1F2A3D4 /* SettingsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D4E5F6A7B8C9D0E1F2A3D5 /* SettingsWindowController.swift */; };
-		1E1A626B793345D19ED17F69 /* ConversationTurn.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFF04372C9864500ACDE31DE /* ConversationTurn.swift */; };
-		5C34EDF9F93F4AF0A49348F0 /* ConversationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A6CB323FE3D41379FF699B3 /* ConversationStore.swift */; };
+		F7BADDC6504BE5C8CBDC71C7 /* SettingsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8280E667A550625C6F5B52C /* SettingsWindowController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		2B3C4D5E6F7A8B9C0D1E2F3A /* ArcReactorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcReactorView.swift; sourceTree = "<group>"; };
+		16DE1934410CC3348DF27C92 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
+		1782D973C548CA02194D931A /* JarvisClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JarvisClient.swift; sourceTree = "<group>"; };
+		28050F6CD9B2DCFF2B910307 /* ConversationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStore.swift; sourceTree = "<group>"; };
 		54CCBC142B08F40AAF2803FF /* HUDWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDWindow.swift; sourceTree = "<group>"; };
 		827BD974D1EDA53447ABD677 /* HUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDView.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F6A7B8C9D0E1F3 /* JarvisClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JarvisClient.swift; sourceTree = "<group>"; };
+		A1DA8E26A20181D485520F5D /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		AF2A2306408B895EC1588A19 /* ArcReactorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcReactorView.swift; sourceTree = "<group>"; };
 		AFDE0C2B9C763CB14D4860EF /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
-		B2C3D4E5F6A7B8C9D0E1F2A4 /* AudioController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioController.swift; sourceTree = "<group>"; };
 		B14F409752942B73285CEBFE /* HUDViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDViewModel.swift; sourceTree = "<group>"; };
-		DFF04372C9864500ACDE31DE /* ConversationTurn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationTurn.swift; sourceTree = "<group>"; };
-		2A6CB323FE3D41379FF699B3 /* ConversationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStore.swift; sourceTree = "<group>"; };
-		C3D4E5F6A7B8C9D0E1F2A3B5 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
-		C3D4E5F6A7B8C9D0E1F2A3C5 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
-		C3D4E5F6A7B8C9D0E1F2A3D5 /* SettingsWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowController.swift; sourceTree = "<group>"; };
-		AA11BB22CC33DD44EE55FF66 /* Jarvis.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Jarvis.xcconfig; sourceTree = "<group>"; };
 		BCD242C83ADE5623EDB958B3 /* Jarvis.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Jarvis.entitlements; sourceTree = "<group>"; };
 		BD65447B9E4C38A85B4132FD /* JarvisApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JarvisApp.swift; sourceTree = "<group>"; };
+		C8280E667A550625C6F5B52C /* SettingsWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowController.swift; sourceTree = "<group>"; };
 		CF188A9690C132DC1EAA28DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		D722C25A1AB2A313C61C2A2F /* ConversationTurn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationTurn.swift; sourceTree = "<group>"; };
 		D758DDA5F42A49B6CB275DED /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		F2EA89B09E63D9954B6EA5A4 /* Jarvis.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Jarvis.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4F2E672EFF61B016C7F5B5B /* ServerAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerAuth.swift; sourceTree = "<group>"; };
+		FE46948996AFC7C505BF9F2D /* AudioController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -56,7 +57,6 @@
 		BC0DCAC9B7584481D8C65021 = {
 			isa = PBXGroup;
 			children = (
-				AA11BB22CC33DD44EE55FF66 /* Jarvis.xcconfig */,
 				FC737B8F8A91C66ADA6702EE /* Jarvis */,
 				7370B301BC3824D8E135198C /* Products */,
 			);
@@ -65,22 +65,23 @@
 		FC737B8F8A91C66ADA6702EE /* Jarvis */ = {
 			isa = PBXGroup;
 			children = (
-				2B3C4D5E6F7A8B9C0D1E2F3A /* ArcReactorView.swift */,
 				CF188A9690C132DC1EAA28DE /* AppDelegate.swift */,
-				B2C3D4E5F6A7B8C9D0E1F2A4 /* AudioController.swift */,
-				2A6CB323FE3D41379FF699B3 /* ConversationStore.swift */,
-				DFF04372C9864500ACDE31DE /* ConversationTurn.swift */,
+				AF2A2306408B895EC1588A19 /* ArcReactorView.swift */,
+				FE46948996AFC7C505BF9F2D /* AudioController.swift */,
+				28050F6CD9B2DCFF2B910307 /* ConversationStore.swift */,
+				D722C25A1AB2A313C61C2A2F /* ConversationTurn.swift */,
 				827BD974D1EDA53447ABD677 /* HUDView.swift */,
 				B14F409752942B73285CEBFE /* HUDViewModel.swift */,
 				54CCBC142B08F40AAF2803FF /* HUDWindow.swift */,
 				D758DDA5F42A49B6CB275DED /* Info.plist */,
 				BCD242C83ADE5623EDB958B3 /* Jarvis.entitlements */,
 				BD65447B9E4C38A85B4132FD /* JarvisApp.swift */,
-				A1B2C3D4E5F6A7B8C9D0E1F3 /* JarvisClient.swift */,
+				1782D973C548CA02194D931A /* JarvisClient.swift */,
 				AFDE0C2B9C763CB14D4860EF /* MenuBarController.swift */,
-				C3D4E5F6A7B8C9D0E1F2A3B5 /* SettingsViewModel.swift */,
-				C3D4E5F6A7B8C9D0E1F2A3C5 /* SettingsView.swift */,
-			C3D4E5F6A7B8C9D0E1F2A3D5 /* SettingsWindowController.swift */,
+				F4F2E672EFF61B016C7F5B5B /* ServerAuth.swift */,
+				A1DA8E26A20181D485520F5D /* SettingsView.swift */,
+				16DE1934410CC3348DF27C92 /* SettingsViewModel.swift */,
+				C8280E667A550625C6F5B52C /* SettingsWindowController.swift */,
 			);
 			path = Jarvis;
 			sourceTree = "<group>";
@@ -115,6 +116,7 @@
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					461D90920FCD8CAF83348871 = {
+						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -143,20 +145,21 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1A2B3C4D5E6F7A8B9C0D1E2F /* ArcReactorView.swift in Sources */,
 				9DC43759D0969F2E2310C9B0 /* AppDelegate.swift in Sources */,
-				B2C3D4E5F6A7B8C9D0E1F2A3 /* AudioController.swift in Sources */,
+				50B5984098E2CA321B052F50 /* ArcReactorView.swift in Sources */,
+				C5A0B5A7794EDAD1DAD54D45 /* AudioController.swift in Sources */,
+				73EB57CE388694AD14C8846D /* ConversationStore.swift in Sources */,
+				20D2689B00846AD289147615 /* ConversationTurn.swift in Sources */,
 				67C0FA63859E57CDAD3386B0 /* HUDView.swift in Sources */,
 				F661D252F7E4C5019639C9E1 /* HUDViewModel.swift in Sources */,
 				80196255C1F1E1FAD02CF1B6 /* HUDWindow.swift in Sources */,
 				5E25349CC3262A18DE554A01 /* JarvisApp.swift in Sources */,
-				A1B2C3D4E5F6A7B8C9D0E1F2 /* JarvisClient.swift in Sources */,
+				9A4605C19C8DED53DB7CFDA9 /* JarvisClient.swift in Sources */,
 				4C532BB72DB8492A9CA01EFA /* MenuBarController.swift in Sources */,
-				C3D4E5F6A7B8C9D0E1F2A3B4 /* SettingsViewModel.swift in Sources */,
-				C3D4E5F6A7B8C9D0E1F2A3C4 /* SettingsView.swift in Sources */,
-			C3D4E5F6A7B8C9D0E1F2A3D4 /* SettingsWindowController.swift in Sources */,
-			1E1A626B793345D19ED17F69 /* ConversationTurn.swift in Sources */,
-			5C34EDF9F93F4AF0A49348F0 /* ConversationStore.swift in Sources */,
+				2A61E147BF98A57F2E45B368 /* ServerAuth.swift in Sources */,
+				38949C6A1B97F9254C8BF611 /* SettingsView.swift in Sources */,
+				5B192FF0418EF35BCAB45133 /* SettingsViewModel.swift in Sources */,
+				F7BADDC6504BE5C8CBDC71C7 /* SettingsWindowController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -165,12 +168,12 @@
 /* Begin XCBuildConfiguration section */
 		06169DA02795A8ED87F6F021 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AA11BB22CC33DD44EE55FF66 /* Jarvis.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Jarvis/Jarvis.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Jarvis/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -248,12 +251,12 @@
 		};
 		B81D099211BB3784F907E95C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AA11BB22CC33DD44EE55FF66 /* Jarvis.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Jarvis/Jarvis.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Jarvis/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/jarvis-swift/Jarvis/AppDelegate.swift
+++ b/jarvis-swift/Jarvis/AppDelegate.swift
@@ -105,6 +105,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         guard let url = URL(string: "http://127.0.0.1:8765/alerts") else { return }
         var request = URLRequest(url: url)
         request.timeoutInterval = 300
+        ServerAuth.apply(to: &request)
         do {
             let (stream, _) = try await URLSession.shared.bytes(for: request)
             var buffer = ""
@@ -267,6 +268,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
                     "--log-level", "warning",
                 ]
                 process.currentDirectoryURL = coreDir
+
+                // Pass the shared auth token so the core rejects requests from any
+                // other local process. Inherit the existing environment and add ours.
+                var env = ProcessInfo.processInfo.environment
+                env["JARVIS_AUTH_TOKEN"] = ServerAuth.token
+                process.environment = env
 
                 do {
                     try process.run()

--- a/jarvis-swift/Jarvis/AudioController.swift
+++ b/jarvis-swift/Jarvis/AudioController.swift
@@ -29,6 +29,7 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
     private var isListening = false
     private var pendingToolUseId: String?
     private var pendingApprovalCategory: String?
+    private var currentCommandId: String?
     private var lastCommandText: String?
     private var stepVoiceEnabled: Bool = false
     private var lastInputWasText = false
@@ -251,12 +252,15 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
         guard let toolUseId = pendingToolUseId else { return }
         let category = pendingApprovalCategory
         let originalCommand = lastCommandText
+        let commandId = currentCommandId ?? ""
         pendingToolUseId = nil
         pendingApprovalCategory = nil
 
         if !approved {
             viewModel.finalizeTurn(response: "Denied.")
             showHUD(.denied)
+            // Tell the server to drop the paused run; fire-and-forget.
+            Task { _ = try? await client.sendApproval(commandId: commandId, toolUseId: toolUseId, approved: false, category: nil) }
             Task {
                 try? await Task.sleep(nanoseconds: 1_500_000_000)
                 await MainActor.run { self.hideHUD() }
@@ -264,32 +268,41 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
             return
         }
 
-        viewModel.finalizeTurn(response: "Approved — re-running…")
+        viewModel.finalizeTurn(response: "Approved…")
         showHUD(.thinking)
         Task { [weak self] in
             guard let self else { return }
-            let shouldReissue = (try? await client.sendApproval(
-                toolUseId: toolUseId, approved: true, category: category
-            )) ?? false
+            let outcome = (try? await client.sendApproval(
+                commandId: commandId, toolUseId: toolUseId, approved: true, category: category
+            )) ?? .cancelled
 
-            if shouldReissue, let text = originalCommand {
-                // Re-issue the original command — guardrails now trust the category for this session.
-                // lastInputWasText is intentionally inherited from the original command: a text-initiated
-                // command that triggers approval will re-issue silently (no TTS), a voice command will speak.
-                // Create a fresh turn for the re-issued command.
+            switch outcome {
+            case .resumed(let response):
+                // Server continued the run in place — render its final result (which may
+                // itself be another approval prompt if a later step is also gated).
+                await MainActor.run {
+                    self.viewModel.finalizeTurn(response: response.text)
+                    self.handleCommandResponse(response)
+                }
+            case .reissue:
+                // No paused state (e.g. server restarted) — replay the original command.
+                // lastInputWasText is inherited: a text-initiated command re-issues silently.
+                guard let text = originalCommand else { await MainActor.run { self.hideHUD() }; return }
                 await MainActor.run { self.viewModel.startTurn(command: text) }
                 do {
-                    let commandId = try await client.startCommand(text: text, cwd: nil)
-                    await self.listenToEvents(commandId: commandId)
+                    let newId = try await client.startCommand(text: text, cwd: nil)
+                    await self.listenToEvents(commandId: newId)
                 } catch {
                     NSLog("[Jarvis] re-issue after approval failed: %@", error.localizedDescription)
                     let msg = "I'm having trouble connecting. Please check that Jarvis is running."
-                    self.viewModel.finalizeTurn(response: msg)
-                    self.showHUD(.response(text: msg))
-                    self.speak(msg)
+                    await MainActor.run {
+                        self.viewModel.finalizeTurn(response: msg)
+                        self.showHUD(.response(text: msg))
+                        self.speak(msg)
+                    }
                 }
-            } else {
-                self.hideHUD()
+            case .cancelled:
+                await MainActor.run { self.hideHUD() }
             }
         }
     }
@@ -310,6 +323,7 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
     // MARK: - SSE
 
     private func listenToEvents(commandId: String) async {
+        currentCommandId = commandId
         let stepVoice = stepVoiceEnabled
         guard let url = URL(string: "http://127.0.0.1:8765/events/\(commandId)") else { return }
         var request = URLRequest(url: url)

--- a/jarvis-swift/Jarvis/AudioController.swift
+++ b/jarvis-swift/Jarvis/AudioController.swift
@@ -297,8 +297,10 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
     // MARK: - Config
 
     func refreshConfig() async {
-        guard let url = URL(string: "http://127.0.0.1:8765/config"),
-              let (data, _) = try? await URLSession.shared.data(from: url),
+        guard let url = URL(string: "http://127.0.0.1:8765/config") else { return }
+        var request = URLRequest(url: url)
+        ServerAuth.apply(to: &request)
+        guard let (data, _) = try? await URLSession.shared.data(for: request),
               let config = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let narration = config["narration"] as? [String: Any]
         else { return }
@@ -312,6 +314,7 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
         guard let url = URL(string: "http://127.0.0.1:8765/events/\(commandId)") else { return }
         var request = URLRequest(url: url)
         request.timeoutInterval = 600
+        ServerAuth.apply(to: &request)
 
         do {
             let (stream, _) = try await URLSession.shared.bytes(for: request)

--- a/jarvis-swift/Jarvis/JarvisClient.swift
+++ b/jarvis-swift/Jarvis/JarvisClient.swift
@@ -105,6 +105,7 @@ final class JarvisClient {
         var body: [String: Any] = ["text": text, "source": "swift"]
         if let cwd { body["cwd"] = cwd }
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        ServerAuth.apply(to: &request)
         // Short timeout — server returns command_id immediately
         let cfg = URLSessionConfiguration.default
         cfg.timeoutIntervalForRequest = 10
@@ -127,6 +128,7 @@ final class JarvisClient {
             body["category"] = category
         }
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        ServerAuth.apply(to: &request)
         let (data, _) = try await quickSession.data(for: request)
         let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         return (json?["next_action"] as? String) == "reissue_command"
@@ -138,6 +140,7 @@ final class JarvisClient {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONSerialization.data(withJSONObject: ["text": text])
+        ServerAuth.apply(to: &request)
         let (data, _) = try await quickSession.data(for: request)
         return try JSONDecoder().decode(ApprovalClassifyResponse.self, from: data).approved
     }

--- a/jarvis-swift/Jarvis/JarvisClient.swift
+++ b/jarvis-swift/Jarvis/JarvisClient.swift
@@ -115,15 +115,24 @@ final class JarvisClient {
         return resp.commandId
     }
 
-    /// Returns true if caller should re-issue the original command.
-    func sendApproval(toolUseId: String, approved: Bool, category: String?) async throws -> Bool {
+    /// Outcome of an approval decision.
+    enum ApprovalOutcome {
+        case resumed(CommandResponse)   // server continued the run; render this result
+        case reissue                    // no paused state — replay the original command
+        case cancelled                  // denied or nothing to do
+    }
+
+    /// Submit an approval decision. On approval the server resumes the paused run in
+    /// place (no replay) and returns the final result; if it can't, it asks the client
+    /// to re-issue the original command.
+    func sendApproval(commandId: String, toolUseId: String, approved: Bool, category: String?) async throws -> ApprovalOutcome {
         var request = URLRequest(url: URL(string: "\(baseURL)/approve")!)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        var body: [String: Any] = ["tool_use_id": toolUseId, "approved": approved]
+        var body: [String: Any] = ["tool_use_id": toolUseId, "approved": approved, "command_id": commandId]
         if approved, let category {
-            // Trust this guardrail category for the rest of the session so the
-            // re-issued command auto-allows without triggering approval again.
+            // Trust this guardrail category for the rest of the session so the resumed
+            // (or re-issued) run auto-allows without triggering approval again.
             body["trust_session"] = true
             body["category"] = category
         }
@@ -131,7 +140,17 @@ final class JarvisClient {
         ServerAuth.apply(to: &request)
         let (data, _) = try await quickSession.data(for: request)
         let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        return (json?["next_action"] as? String) == "reissue_command"
+        switch json?["next_action"] as? String {
+        case "resumed":
+            if let response = try? JSONDecoder().decode(CommandResponse.self, from: data) {
+                return .resumed(response)
+            }
+            return .cancelled
+        case "reissue_command":
+            return .reissue
+        default:
+            return .cancelled
+        }
     }
 
     /// Returns true (approved), false (denied), or nil (unclear — caller should stay in approval state)

--- a/jarvis-swift/Jarvis/MenuBarController.swift
+++ b/jarvis-swift/Jarvis/MenuBarController.swift
@@ -82,6 +82,7 @@ final class MenuBarController {
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         req.httpBody = body
+        ServerAuth.apply(to: &req)
         URLSession.shared.dataTask(with: req) { _, response, error in
             guard error == nil,
                   let http = response as? HTTPURLResponse,
@@ -96,6 +97,7 @@ final class MenuBarController {
         guard let url = URL(string: "http://127.0.0.1:8765/reset") else { return }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
+        ServerAuth.apply(to: &request)
         URLSession.shared.dataTask(with: request).resume()
         // Clear the Swift-side conversation thread and save the session
         DispatchQueue.main.async { [weak self] in
@@ -105,7 +107,9 @@ final class MenuBarController {
 
     func syncAwayState() {
         guard let url = URL(string: "http://127.0.0.1:8765/telegram/away") else { return }
-        URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
+        var request = URLRequest(url: url)
+        ServerAuth.apply(to: &request)
+        URLSession.shared.dataTask(with: request) { [weak self] data, _, _ in
             guard let data,
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Bool],
                   let away = json["away"] else { return }

--- a/jarvis-swift/Jarvis/ServerAuth.swift
+++ b/jarvis-swift/Jarvis/ServerAuth.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Shared secret between this app and the local Jarvis Python core.
+///
+/// The token is generated once per app launch and passed to the Python process via
+/// the JARVIS_AUTH_TOKEN environment variable at spawn (see AppDelegate). Every HTTP
+/// request to the core must carry it as the `X-Jarvis-Token` header, so other local
+/// processes can't drive the server (which can run shell commands and edit files).
+enum ServerAuth {
+    static let headerField = "X-Jarvis-Token"
+
+    /// Stable for the lifetime of the app process. `static let` initializes lazily once.
+    static let token: String = UUID().uuidString
+
+    /// Attach the auth header to an outgoing request.
+    static func apply(to request: inout URLRequest) {
+        request.setValue(token, forHTTPHeaderField: headerField)
+    }
+}

--- a/jarvis-swift/Jarvis/SettingsViewModel.swift
+++ b/jarvis-swift/Jarvis/SettingsViewModel.swift
@@ -73,7 +73,9 @@ final class SettingsViewModel: ObservableObject {
         saveError = nil
         defer { isLoading = false }
         guard let url = URL(string: "\(baseURL)/config") else { return }
-        guard let (data, response) = try? await URLSession.shared.data(from: url),
+        var loadRequest = URLRequest(url: url)
+        ServerAuth.apply(to: &loadRequest)
+        guard let (data, response) = try? await URLSession.shared.data(for: loadRequest),
               (response as? HTTPURLResponse)?.statusCode == 200,
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             saveError = "Could not load config — is Jarvis running?"
@@ -163,6 +165,7 @@ final class SettingsViewModel: ObservableObject {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = body
+        ServerAuth.apply(to: &request)
 
         guard let (_, response) = try? await URLSession.shared.data(for: request),
               (response as? HTTPURLResponse)?.statusCode == 200 else {


### PR DESCRIPTION
## Summary
- fix Phase A stabilization issues around stall handling, DDG snippets, run_code guardrails, and routing defaults
- centralize backend resolution and fix split-brain executor/classifier/embedder behavior
- add shared-secret auth between the Swift app and Python core
- resume approved commands in place instead of replaying them, with persisted approval state

## Verification
- 340/340 tests passing during Phase A execution
- Swift app builds cleanly
