### PR TITLE
Phase B: Local-First Consolidation

### DIFF
--- a/jarvis-core/README.md
+++ b/jarvis-core/README.md
@@ -63,8 +63,12 @@ Stored at `~/.jarvis/config.json`. Key fields:
   "brave_api_key": "",
   "ollama": {
     "host": "http://localhost:11434",
-    "model": "llama3.1:8b",
-    "routing_mode": "haiku_first"
+    "model": "qwen3.6:35b-a3b",
+    "routing_mode": "local_first",
+    "executor_host": "http://localhost:11434",
+    "executor_model": "qwen3.6:35b-a3b",
+    "classifier_host": "http://127.0.0.1:8090",
+    "classifier_model": "mlx-community/Qwen3-4B-Instruct-2507-4bit"
   },
   "models": {
     "haiku": "claude-haiku-4-5-20251001",
@@ -79,7 +83,8 @@ Stored at `~/.jarvis/config.json`. Key fields:
 
 ## Routing Modes
 
-- `haiku_first` (default) — Ollama classifies intent, routes to Haiku or Sonnet
+- `local_first` (default) — local executor handles non-complex tasks, Sonnet reserved for `complex_reasoning`
+- `haiku_first` — Ollama classifies intent, routes to Haiku or Sonnet
 - `ollama_only` — local only, no Claude API calls
 - `claude_only` — always uses Claude, skips Ollama classifier
 

--- a/jarvis-core/agent.py
+++ b/jarvis-core/agent.py
@@ -63,6 +63,7 @@ TOOL_DEFINITIONS = [
             "properties": {
                 "command": {"type": "string", "description": "The shell command to run"},
                 "cwd": {"type": "string", "description": "Working directory (optional, defaults to active project)"},
+                "timeout": {"type": "integer", "description": "Timeout in seconds (default 30, max 600). Use for long-running builds or test suites."},
             },
             "required": ["command"],
         },

--- a/jarvis-core/approval_store.py
+++ b/jarvis-core/approval_store.py
@@ -25,6 +25,11 @@ def has(command_id: str) -> bool:
     return command_id in _PAUSED
 
 
+def get(command_id: str) -> dict | None:
+    """Read a paused run entry without removing it."""
+    return _PAUSED.get(command_id)
+
+
 def pop(command_id: str) -> dict | None:
     return _PAUSED.pop(command_id, None)
 

--- a/jarvis-core/benchmark_gemma.py
+++ b/jarvis-core/benchmark_gemma.py
@@ -1,0 +1,524 @@
+"""Gemma 4 31B executor benchmark — 50 cases across all tool types.
+
+Usage:
+    cd jarvis-core && source .venv/bin/activate
+    python benchmark_gemma.py
+    python benchmark_gemma.py --models gemma4:31b,qwen3-coder:30b
+    python benchmark_gemma.py --timeout 120 --num-ctx 16384
+"""
+
+import argparse
+import json
+import statistics
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+import httpx
+
+
+# ---------------------------------------------------------------------------
+# Tools definition (mirrors Jarvis tool set)
+# ---------------------------------------------------------------------------
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "shell_run",
+            "description": "Run a shell command on macOS",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string", "description": "Shell command to run"}},
+                "required": ["command"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "web_search",
+            "description": "Search the web for information",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string", "description": "Search query"}},
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "run_code",
+            "description": "Execute a code snippet and return the output",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "code": {"type": "string", "description": "Code to execute"},
+                    "language": {"type": "string", "description": "Programming language (python, bash, etc.)"},
+                },
+                "required": ["code"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "open_app",
+            "description": "Open a macOS application by name",
+            "parameters": {
+                "type": "object",
+                "properties": {"name": {"type": "string", "description": "Application name"}},
+                "required": ["name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "file_read",
+            "description": "Read the contents of a file",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string", "description": "File path to read"}},
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "file_write",
+            "description": "Write content to a file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "File path to write"},
+                    "content": {"type": "string", "description": "Content to write"},
+                },
+                "required": ["path", "content"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "notify",
+            "description": "Send a macOS system notification",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "message": {"type": "string"},
+                },
+                "required": ["title", "message"],
+            },
+        },
+    },
+]
+
+SYSTEM_PROMPT = """\
+You are Jarvis, a macOS AI assistant. You act by calling tools — you NEVER respond with plain text alone.
+
+ABSOLUTE RULES — no exceptions:
+1. You MUST call a tool for every single request. A text-only response is always wrong.
+2. If a task involves multiple steps, call the FIRST tool immediately. Do not explain the plan.
+3. The user cannot execute anything themselves — you are their hands. If you do not call a tool, nothing happens.
+4. NEVER say "I would run..." or "You can use..." — just call the tool.
+
+Tool routing — always use the most direct tool:
+- Shell commands, file listings, git operations, process info, system info (date, time, disk, memory, uptime), finding files by attribute (size, age, pattern), counting lines, grepping — ALL use shell_run
+- Web lookups, current events, documentation, prices, weather → web_search
+- Execute code that produces output (Python, JS, TypeScript, Ruby, Swift) → run_code
+- Open a macOS application → open_app
+- Read a file's contents → file_read  (NEVER use shell_run to cat/head/tail a file — ALWAYS use file_read)
+- Write or create a file → file_write
+- macOS system notification → notify
+
+Critical examples — call the tool immediately:
+- "find Python files modified today" → shell_run(command="find . -name '*.py' -mtime -1")
+- "count lines of code" → shell_run(command="find . -name '*.py' | xargs wc -l")
+- "show git log" → shell_run(command="git log --oneline -10")
+- "what time is it" → shell_run(command="date")
+- "write a script to /tmp/x.py" → file_write(path="/tmp/x.py", content="...")
+- "run a function that reverses a string" → run_code(code="def reverse(s): return s[::-1]\\nprint(reverse('hello'))")
+- "read the requirements.txt file" → file_read(path="requirements.txt")
+"""
+
+# ---------------------------------------------------------------------------
+# 50 test cases
+# Format: (command, expected_tool, category, notes)
+# categories: simple | multi_step | reasoning | edge
+# ---------------------------------------------------------------------------
+
+CASES = [
+    # ── shell_run — simple (10) ─────────────────────────────────────────────
+    ("list files in ~/Downloads",                       "shell_run",        "simple",     ""),
+    ("run git status in ~/dev/jarvis",                  "shell_run",        "simple",     ""),
+    ("run the test suite with pytest",                  "shell_run",        "simple",     ""),
+    ("execute this bash script: echo hello",            "shell_run",        "simple",     ""),
+    ("show all running Python processes",               "shell_run",        "simple",     ""),
+    ("get the current macOS version",                   "shell_run",        "simple",     ""),
+    ("show disk usage of my home directory",            "shell_run",        "simple",     ""),
+    ("list all git branches in the project",            "shell_run",        "simple",     ""),
+    ("check if port 8765 is currently in use",          "shell_run",        "simple",     ""),
+    ("show currently installed Homebrew packages",      "shell_run",        "simple",     ""),
+
+    # ── shell_run — multi-step / reasoning (10) ────────────────────────────
+    ("find all Python files modified in the last 24 hours",                         "shell_run", "multi_step", "needs find -mtime"),
+    ("search for all TODO comments recursively in the src directory",               "shell_run", "multi_step", "grep -r"),
+    ("count the total lines of code in jarvis-core, excluding the venv",           "shell_run", "multi_step", "find + wc"),
+    ("show the 5 largest files in ~/Downloads sorted by size",                     "shell_run", "multi_step", "find + sort"),
+    ("find and list all .log files older than 7 days in ~/.jarvis/logs",           "shell_run", "multi_step", "find -mtime +7"),
+    ("show which process is using the most CPU right now",                         "shell_run", "reasoning",  "ps or top"),
+    ("check if the Python FastAPI server on port 8765 is responding",              "shell_run", "reasoning",  "curl localhost"),
+    ("show the git log of the last 10 commits with author and date",               "shell_run", "reasoning",  "git log format"),
+    ("list all environment variables that contain the word PATH",                  "shell_run", "reasoning",  "env | grep"),
+    ("show all open network connections on this machine",                          "shell_run", "reasoning",  "netstat or lsof"),
+
+    # ── web_search (8) ─────────────────────────────────────────────────────
+    ("search the web for FastAPI documentation",                    "web_search", "simple",   ""),
+    ("check the weather online",                                    "web_search", "simple",   ""),
+    ("search for Python list sorting best practices",               "web_search", "simple",   ""),
+    ("find the latest Claude API pricing from Anthropic",           "web_search", "simple",   ""),
+    ("look up how to configure Ollama to use a custom model",       "web_search", "reasoning",""),
+    ("search for how to resolve a git merge conflict",              "web_search", "simple",   ""),
+    ("find out what's new in Python 3.13",                         "web_search", "simple",   ""),
+    ("search for benchmarks comparing llama3 vs gemma on coding",  "web_search", "reasoning",""),
+
+    # ── run_code (7) ────────────────────────────────────────────────────────
+    ("run this Python snippet: print(1+1)",                                         "run_code", "simple",   ""),
+    ("calculate the fibonacci sequence up to index 10 in Python",                  "run_code", "reasoning",""),
+    ("run a Python script that prints all even numbers between 1 and 20",          "run_code", "simple",   ""),
+    ("execute a quick Python check of the current Python version",                 "run_code", "simple",   ""),
+    ("run: import json; print(json.dumps({'status': 'ok', 'version': 3}))",        "run_code", "simple",   ""),
+    ("write and run a Python function that reverses a string and tests it",        "run_code", "reasoning",""),
+    ("run a bash snippet that prints the current date and hostname",               "shell_run", "simple",   "bash → shell_run"),
+
+    # ── open_app (5) ───────────────────────────────────────────────────────
+    ("open Safari",                    "open_app", "simple",   ""),
+    ("open the Finder app",            "open_app", "simple",   ""),
+    ("open VS Code",                   "open_app", "simple",   ""),
+    ("launch the Terminal application","open_app", "simple",   ""),
+    ("open System Preferences",        "open_app", "simple",   ""),
+
+    # ── file_read (5) ──────────────────────────────────────────────────────
+    ("read the file README.md",                         "file_read", "simple",   ""),
+    ("show the contents of /tmp/test.txt",              "file_read", "simple",   ""),
+    ("read my Jarvis config file at ~/.jarvis/config.json","file_read","simple",  ""),
+    ("show me the contents of jarvis-core/server.py",  "file_read", "simple",   ""),
+    ("read the requirements.txt file",                 "file_read", "simple",   ""),
+
+    # ── file_write (5) ─────────────────────────────────────────────────────
+    ("write 'hello world' to /tmp/test.txt",                                    "file_write", "simple",   ""),
+    ("create a new file called notes.md with content 'my notes'",              "file_write", "simple",   ""),
+    ("save the text 'benchmark run complete' to /tmp/benchmark_log.txt",       "file_write", "simple",   ""),
+    ("create a file at /tmp/ideas.txt with the content 'brainstorm session'",  "file_write", "simple",   ""),
+    ("write a simple Python hello world script to /tmp/hello.py",              "file_write", "reasoning","needs code content"),
+
+    # ── notify (3) ─────────────────────────────────────────────────────────
+    ("notify me that the build finished",               "notify", "simple",   ""),
+    ("send a notification that deployment is complete", "notify", "simple",   ""),
+    ("alert me with a macOS notification that the tests passed", "notify", "simple", ""),
+
+    # ── edge / ambiguous (7) ───────────────────────────────────────────────
+    ("what time is it?",                                "shell_run",   "edge", "date command"),
+    ("show me today's date and day of the week",       "shell_run",   "edge", "date"),
+    ("check if ollama is running on this machine",     "shell_run",   "edge", "ps or curl"),
+    ("what's my current working directory?",           "shell_run",   "edge", "pwd"),
+    ("show me the memory usage of the system",         "shell_run",   "edge", "vm_stat or free"),
+    ("how much free disk space do I have?",            "shell_run",   "edge", "df -h"),
+    ("is the jarvis-core server currently running?",   "shell_run",   "edge", "ps or curl"),
+]
+
+assert len(CASES) >= 50, f"Expected at least 50 cases, got {len(CASES)}"
+
+# Required args per tool — used for argument quality check
+REQUIRED_ARGS = {
+    "shell_run":   ["command"],
+    "web_search":  ["query"],
+    "run_code":    ["code"],
+    "open_app":    ["name"],
+    "file_read":   ["path"],
+    "file_write":  ["path", "content"],
+    "notify":      ["title", "message"],
+}
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Result:
+    model: str
+    num_ctx: int
+    total: int = 0
+    tool_correct: int = 0
+    args_valid: int = 0          # required args present + non-empty
+    completed: int = 0           # got any tool call at all
+    bad_json: int = 0
+    errors: int = 0
+    latencies: list = field(default_factory=list)
+    completion_tok_s: list = field(default_factory=list)
+    # per-category breakdown
+    category_correct: dict = field(default_factory=lambda: {
+        "simple": [0, 0], "multi_step": [0, 0], "reasoning": [0, 0], "edge": [0, 0]
+    })
+
+    @property
+    def tool_acc_pct(self) -> float:
+        return (self.tool_correct / self.total * 100) if self.total else 0
+
+    @property
+    def args_acc_pct(self) -> float:
+        return (self.args_valid / self.total * 100) if self.total else 0
+
+    @property
+    def p50(self) -> float:
+        return statistics.median(self.latencies) if self.latencies else 0
+
+    @property
+    def p95(self) -> float:
+        if not self.latencies:
+            return 0
+        s = sorted(self.latencies)
+        return s[min(int(len(s) * 0.95), len(s) - 1)]
+
+    @property
+    def avg_latency(self) -> float:
+        return statistics.mean(self.latencies) if self.latencies else 0
+
+    @property
+    def avg_tok_s(self) -> float:
+        return statistics.mean(self.completion_tok_s) if self.completion_tok_s else 0
+
+    @property
+    def p50_tok_s(self) -> float:
+        return statistics.median(self.completion_tok_s) if self.completion_tok_s else 0
+
+    def to_dict(self) -> dict:
+        return {
+            "model": self.model,
+            "num_ctx": self.num_ctx,
+            "total": self.total,
+            "tool_correct": self.tool_correct,
+            "args_valid": self.args_valid,
+            "completed": self.completed,
+            "bad_json": self.bad_json,
+            "errors": self.errors,
+            "tool_acc_pct": self.tool_acc_pct,
+            "args_acc_pct": self.args_acc_pct,
+            "avg_latency_ms": self.avg_latency,
+            "p50_latency_ms": self.p50,
+            "p95_latency_ms": self.p95,
+            "avg_completion_tok_s": self.avg_tok_s,
+            "p50_completion_tok_s": self.p50_tok_s,
+            "category_correct": self.category_correct,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Benchmark runner
+# ---------------------------------------------------------------------------
+
+def run_benchmark(
+    model: str,
+    host: str,
+    timeout: float,
+    num_ctx: int,
+    cases: list[tuple[str, str, str, str]],
+    chat_template_kwargs: Optional[dict] = None,
+) -> Result:
+    result = Result(model=model, num_ctx=num_ctx, total=len(cases))
+    width = max(len(c[0]) for c in cases)
+
+    with httpx.Client(timeout=timeout) as client:
+        for idx, (command, expected_tool, category, _notes) in enumerate(cases, 1):
+            t0 = time.monotonic()
+            try:
+                payload = {
+                    "model": model,
+                    "messages": [
+                        {"role": "system", "content": SYSTEM_PROMPT},
+                        {"role": "user", "content": command},
+                    ],
+                    "tools": TOOLS,
+                    "options": {"num_ctx": num_ctx},
+                }
+                if chat_template_kwargs is not None:
+                    payload["chat_template_kwargs"] = chat_template_kwargs
+
+                resp = client.post(
+                    f"{host}/v1/chat/completions",
+                    json=payload,
+                )
+                resp.raise_for_status()
+                body = resp.json()
+                message = body["choices"][0]["message"]
+                tool_calls = message.get("tool_calls")
+            except Exception as exc:
+                elapsed_ms = (time.monotonic() - t0) * 1000
+                result.latencies.append(elapsed_ms)
+                result.errors += 1
+                print(f"  [{idx:02d}/{len(cases):02d}] ERR  {command[:60]:<60}  ({elapsed_ms:.0f}ms)  error: {exc}")
+                continue
+
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            result.latencies.append(elapsed_ms)
+            usage = body.get("usage") or {}
+            completion_tokens = usage.get("completion_tokens") or 0
+            tok_s = (completion_tokens / (elapsed_ms / 1000.0)) if elapsed_ms > 0 and completion_tokens else 0
+            if tok_s:
+                result.completion_tok_s.append(tok_s)
+
+            # Normalise text-based tool calls (qwen-style fallback)
+            if not tool_calls:
+                raw = (message.get("content") or "").strip()
+                if raw.startswith("{"):
+                    try:
+                        parsed = json.loads(raw)
+                        if "name" in parsed:
+                            tool_calls = [{"function": {
+                                "name": parsed["name"],
+                                "arguments": json.dumps(parsed.get("arguments", {})),
+                            }}]
+                    except json.JSONDecodeError:
+                        pass
+
+            if not tool_calls:
+                result.bad_json += 1
+                print(f"  [{idx:02d}/{len(cases):02d}] MISS {command[:60]:<60}  ({elapsed_ms:.0f}ms)  no tool call (expected {expected_tool})")
+                continue
+
+            result.completed += 1
+            got_tool = tool_calls[0]["function"]["name"]
+            tool_ok = got_tool == expected_tool
+
+            # Argument quality check
+            try:
+                args = json.loads(tool_calls[0]["function"]["arguments"])
+                required = REQUIRED_ARGS.get(got_tool, [])
+                args_ok = all(args.get(k, "").strip() for k in required)
+            except (json.JSONDecodeError, AttributeError):
+                args = {}
+                args_ok = False
+
+            if tool_ok:
+                result.tool_correct += 1
+                result.category_correct[category][0] += 1
+            if tool_ok and args_ok:
+                result.args_valid += 1
+
+            result.category_correct[category][1] += 1
+
+            status = "OK  " if tool_ok else "FAIL"
+            arg_flag = "args✓" if args_ok else "args✗"
+            tok_s_text = f"{tok_s:.1f} tok/s" if tok_s else "tok/s n/a"
+            print(
+                f"  [{idx:02d}/{len(cases):02d}] {status} {command[:60]:<60}  ({elapsed_ms:.0f}ms)  "
+                f"got={got_tool}  exp={expected_tool}  {arg_flag}  {tok_s_text}"
+            )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+def print_report(results: list[Result], total_cases: int) -> None:
+    print("\n" + "=" * 90)
+    print(f"EXECUTOR BENCHMARK — {total_cases} CASES")
+    print("=" * 90)
+
+    for r in sorted(results, key=lambda x: x.tool_acc_pct, reverse=True):
+        print(f"\nModel: {r.model}  (num_ctx={r.num_ctx})")
+        print(f"  Tool accuracy:   {r.tool_correct}/{r.total}  ({r.tool_acc_pct:.1f}%)")
+        print(f"  Args quality:    {r.args_valid}/{r.total}   ({r.args_acc_pct:.1f}%)")
+        print(f"  Completed calls: {r.completed}/{r.total}")
+        print(f"  Bad/no tool:     {r.bad_json}   Errors: {r.errors}")
+        print(f"  Latency:         avg={r.avg_latency:.0f}ms  p50={r.p50:.0f}ms  p95={r.p95:.0f}ms")
+        print(f"  Throughput:      avg={r.avg_tok_s:.1f} tok/s  p50={r.p50_tok_s:.1f} tok/s")
+        print()
+        print("  Category breakdown:")
+        for cat, (correct, total) in r.category_correct.items():
+            bar = "█" * correct + "░" * (total - correct)
+            pct = (correct / total * 100) if total else 0
+            print(f"    {cat:<12} {correct:>2}/{total:<2}  {pct:5.1f}%  {bar}")
+
+    print("\n" + "=" * 90)
+    if results:
+        best = max(results, key=lambda x: x.tool_acc_pct)
+        print(f"Best: {best.model} — {best.tool_acc_pct:.1f}% tool accuracy, {best.p50:.0f}ms p50")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Gemma 4 31B executor benchmark (50 cases)")
+    parser.add_argument(
+        "--models",
+        default="gemma4:31b",
+        help="Comma-separated model tags (default: gemma4:31b)",
+    )
+    parser.add_argument("--host", default="http://localhost:11434")
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument(
+        "--num-ctx", type=int, default=8192,
+        help="Context window size passed to Ollama (default: 8192). "
+             "Use 32768 for coding/multi-step tasks.",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=0,
+        help="Run only the first N benchmark cases (default: all cases).",
+    )
+    parser.add_argument(
+        "--chat-template-args", default="",
+        help='Optional JSON passed as chat_template_kwargs, e.g. \'{"enable_thinking": false}\'',
+    )
+    parser.add_argument(
+        "--output", default="",
+        help="Optional path to save benchmark results JSON.",
+    )
+    args = parser.parse_args()
+    models = [m.strip() for m in args.models.split(",") if m.strip()]
+    cases = CASES[: args.limit] if args.limit > 0 else CASES
+    chat_template_kwargs = json.loads(args.chat_template_args) if args.chat_template_args else None
+
+    results = []
+    for model in models:
+        print(f"\n{'=' * 60}")
+        print(f"Benchmarking: {model}  (num_ctx={args.num_ctx}, cases={len(cases)})")
+        print(f"{'=' * 60}")
+        results.append(
+            run_benchmark(
+                model,
+                args.host,
+                args.timeout,
+                args.num_ctx,
+                cases,
+                chat_template_kwargs=chat_template_kwargs,
+            )
+        )
+
+    print_report(results, total_cases=len(cases))
+
+    if args.output:
+        payload = {
+            "generated_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "host": args.host,
+            "limit": args.limit,
+            "num_ctx": args.num_ctx,
+            "chat_template_kwargs": chat_template_kwargs,
+            "results": [r.to_dict() for r in results],
+        }
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+        print(f"\nSaved results to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/jarvis-core/benchmark_gemma.py
+++ b/jarvis-core/benchmark_gemma.py
@@ -328,6 +328,7 @@ def run_benchmark(
     num_ctx: int,
     cases: list[tuple[str, str, str, str]],
     chat_template_kwargs: Optional[dict] = None,
+    rapid_mlx: bool = False,
 ) -> Result:
     result = Result(model=model, num_ctx=num_ctx, total=len(cases))
     width = max(len(c[0]) for c in cases)
@@ -343,9 +344,11 @@ def run_benchmark(
                         {"role": "user", "content": command},
                     ],
                     "tools": TOOLS,
-                    "options": {"num_ctx": num_ctx},
                 }
-                if chat_template_kwargs is not None:
+                if not rapid_mlx:
+                    # Ollama-specific context window option
+                    payload["options"] = {"num_ctx": num_ctx}
+                if not rapid_mlx and chat_template_kwargs is not None:
                     payload["chat_template_kwargs"] = chat_template_kwargs
 
                 resp = client.post(
@@ -480,6 +483,10 @@ def main() -> None:
         help='Optional JSON passed as chat_template_kwargs, e.g. \'{"enable_thinking": false}\'',
     )
     parser.add_argument(
+        "--rapid-mlx", action="store_true",
+        help="Target a Rapid-MLX server: omit Ollama-specific options/chat_template_kwargs fields.",
+    )
+    parser.add_argument(
         "--output", default="",
         help="Optional path to save benchmark results JSON.",
     )
@@ -491,7 +498,7 @@ def main() -> None:
     results = []
     for model in models:
         print(f"\n{'=' * 60}")
-        print(f"Benchmarking: {model}  (num_ctx={args.num_ctx}, cases={len(cases)})")
+        print(f"Benchmarking: {model}  (num_ctx={args.num_ctx}, cases={len(cases)}, rapid_mlx={args.rapid_mlx})")
         print(f"{'=' * 60}")
         results.append(
             run_benchmark(
@@ -501,6 +508,7 @@ def main() -> None:
                 args.num_ctx,
                 cases,
                 chat_template_kwargs=chat_template_kwargs,
+                rapid_mlx=args.rapid_mlx,
             )
         )
 

--- a/jarvis-core/classifier_prompt.py
+++ b/jarvis-core/classifier_prompt.py
@@ -1,0 +1,18 @@
+CLASSIFY_SYSTEM_PROMPT = """You are a command classifier. Analyze the user request and return ONLY a JSON object — no other text.
+
+Return exactly this structure:
+{
+  "can_handle_locally": true or false,
+  "intent_class": "read_only" or "prepare" or "destructive" or "complex_reasoning",
+  "reason": "one sentence explanation"
+}
+
+Rules for can_handle_locally:
+- true: task needs only file ops, shell commands, app control, code execution, OS queries
+- false: task needs web search, current news/prices, advanced code generation, deep reasoning
+
+Rules for intent_class:
+- read_only: just reading or querying, no changes (list files, read a file, show git log, check dependencies, explain code, search a codebase)
+- prepare: will make changes the user should preview (generate code, draft text, move files)
+- destructive: deletes files, sends messages, modifies system settings, irreversible actions
+- complex_reasoning: needs web search, real-time data, or external information NOT available on this machine (news, prices, current events, remote APIs, live documentation). Git history, local files, installed packages, running processes, and codebase questions are NOT complex_reasoning — they are read_only."""

--- a/jarvis-core/command_pipeline.py
+++ b/jarvis-core/command_pipeline.py
@@ -1,3 +1,4 @@
+import threading
 import time
 import uuid
 import logging
@@ -40,7 +41,7 @@ class CommandPipeline:
         self._router = router
         self._memory = memory
         self._registry: dict[str, JarvisCommand] = {}
-        self._executing: bool = False
+        self._lock = threading.Lock()
         self._current_command_id: str | None = None
         self._logger = logging.getLogger("jarvis.commands")
 
@@ -68,12 +69,11 @@ class CommandPipeline:
         """Submit a command. Returns busy response if another command is executing.
         command_id, when given, is the correlation id used to key a paused run so it
         can be resumed after approval (see resume())."""
-        if self._executing:
+        if not self._lock.acquire(blocking=False):
             return {"busy": True, "command_id": self._current_command_id}
 
         cmd = self._create_command(text, cwd, source)
         self._register(cmd)
-        self._executing = True
         self._current_command_id = cmd.id
 
         # Load project memory context
@@ -105,22 +105,21 @@ class CommandPipeline:
             cmd.completed_at = time.time()
             raise
         finally:
-            self._executing = False
             self._current_command_id = None
+            self._lock.release()
 
     def resume(self, command_id: str, step_callback=None) -> dict | None:
         """Continue a run paused for approval, under the single-command lock.
         Returns the final result, None if there is no paused run (caller falls back
         to replay), or a busy response if another command is executing."""
-        if self._executing:
+        if not self._lock.acquire(blocking=False):
             return {"busy": True, "command_id": self._current_command_id}
-        self._executing = True
         self._current_command_id = command_id
         try:
             return self._router.resume(command_id, step_callback=step_callback)
         finally:
-            self._executing = False
             self._current_command_id = None
+            self._lock.release()
 
     def cancel(self, command_id: str) -> dict:
         """Cancel an executing command and release the lock."""
@@ -130,8 +129,9 @@ class CommandPipeline:
         cmd.status = CommandStatus.CANCELLED
         cmd.completed_at = time.time()
         if self._current_command_id == command_id:
-            self._executing = False
             self._current_command_id = None
+            if self._lock.locked():
+                self._lock.release()
         return {"cancelled": True, "command_id": command_id}
 
     def reset_conversation(self) -> None:
@@ -140,8 +140,9 @@ class CommandPipeline:
 
     def abort(self) -> dict:
         """Force-release the lock unconditionally. Emergency escape hatch."""
-        self._executing = False
         self._current_command_id = None
+        if self._lock.locked():
+            self._lock.release()
         return {"lock_released": True}
 
     def get(self, command_id: str) -> JarvisCommand | None:

--- a/jarvis-core/config.example.json
+++ b/jarvis-core/config.example.json
@@ -4,9 +4,16 @@
   "hotkey": "ctrl+space",
   "ollama": {
     "host": "http://localhost:11434",
-    "model": "llama3.1:8b",
-    "routing_mode": "haiku_first",
-    "timeout_seconds": 30
+    "model": "qwen3.6:35b-a3b",
+    "routing_mode": "local_first",
+    "timeout_seconds": 300,
+    "executor_host": "http://localhost:11434",
+    "executor_model": "qwen3.6:35b-a3b",
+    "executor_chat_template_kwargs": {
+      "enable_thinking": false
+    },
+    "classifier_host": "http://127.0.0.1:8090",
+    "classifier_model": "mlx-community/Qwen3-4B-Instruct-2507-4bit"
   },
   "models": {
     "haiku": "claude-haiku-4-5-20251001",

--- a/jarvis-core/config.py
+++ b/jarvis-core/config.py
@@ -36,6 +36,7 @@ DEFAULTS = {
         "executor_chat_template_kwargs": {"enable_thinking": False},
         "classifier_host": "http://127.0.0.1:8090",
         "classifier_model": "mlx-community/Qwen3-4B-Instruct-2507-4bit",
+        "classifier_adapter_path": "",
     },
     "reasoning": {
         "max_steps_claude": 10,

--- a/jarvis-core/config.py
+++ b/jarvis-core/config.py
@@ -28,11 +28,11 @@ DEFAULTS = {
     },
     "ollama": {
         "host": "http://localhost:11434",
-        "model": "qwen35-opus-jarvis",
+        "model": "qwen3.6:35b-a3b",
         "routing_mode": "local_first",   # local_first | haiku_first | ollama_first | claude_only | ollama_only
         "timeout_seconds": 300,
-        "executor_host": "http://127.0.0.1:8090",
-        "executor_model": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
+        "executor_host": "http://localhost:11434",
+        "executor_model": "qwen3.6:35b-a3b",
         "executor_chat_template_kwargs": {"enable_thinking": False},
         "classifier_host": "http://127.0.0.1:8090",
         "classifier_model": "mlx-community/Qwen3-4B-Instruct-2507-4bit",

--- a/jarvis-core/config.py
+++ b/jarvis-core/config.py
@@ -31,8 +31,9 @@ DEFAULTS = {
         "model": "qwen3.6:35b-a3b",
         "routing_mode": "local_first",   # local_first | haiku_first | ollama_first | claude_only | ollama_only
         "timeout_seconds": 300,
-        "executor_host": "http://localhost:11434",
-        "executor_model": "qwen3.6:35b-a3b",
+        "executor_host": "http://127.0.0.1:8093",
+        "executor_model": "mlx-community/Qwen3.6-35B-A3B-4bit",
+        "executor_rapid_mlx": True,
         "executor_chat_template_kwargs": {"enable_thinking": False},
         "classifier_host": "http://127.0.0.1:8090",
         "classifier_model": "mlx-community/Qwen3-4B-Instruct-2507-4bit",

--- a/jarvis-core/finetune_data/curate.py
+++ b/jarvis-core/finetune_data/curate.py
@@ -1,0 +1,237 @@
+import argparse
+import ast
+import json
+import random
+from collections import Counter
+from pathlib import Path
+
+VALID_INTENTS = {"read_only", "prepare", "destructive", "complex_reasoning"}
+BAD_TEXT_MARKERS = (
+    "ran out of steps",
+    "i hit the api rate limit",
+    "i'm experiencing an error",
+    "please try again or restart jarvis",
+)
+DEFAULT_TRAINING_LOG = Path.home() / ".jarvis" / "logs" / "training.log"
+DEFAULT_OUTPUT_DIR = Path.home() / ".jarvis" / "training" / "executor_dataset"
+
+
+def load_records(path: Path) -> list[dict]:
+    if not path.exists():
+        raise FileNotFoundError(f"training log not found: {path}")
+
+    records = []
+    with path.open(encoding="utf-8") as f:
+        for lineno, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                print(f"[curate] skipping malformed JSON on line {lineno}")
+    return records
+
+
+def _text_blob(record: dict) -> str:
+    return " ".join(str(record.get(key) or "") for key in ("display", "speak")).lower()
+
+
+def is_successful_executor_record(record: dict) -> bool:
+    if not record.get("model"):
+        return False
+    if record.get("intent_class") not in VALID_INTENTS:
+        return False
+    if not record.get("steps"):
+        return False
+    if not (record.get("display") or record.get("speak")):
+        return False
+    text = _text_blob(record)
+    if any(marker in text for marker in BAD_TEXT_MARKERS):
+        return False
+    return True
+
+
+def parse_step_arguments(step: dict) -> dict:
+    raw = step.get("input_summary") or "{}"
+    try:
+        parsed = ast.literal_eval(raw)
+    except (SyntaxError, ValueError):
+        return {"raw_input_summary": raw}
+    if isinstance(parsed, dict):
+        return parsed
+    return {"raw_input_summary": raw}
+
+
+def build_executor_example(record: dict) -> dict:
+    messages = [{"role": "user", "content": record["request"]}]
+    for idx, step in enumerate(record.get("steps", []), 1):
+        tool_name = step.get("tool", "unknown_tool")
+        tool_call_id = f"call_{idx}"
+        arguments = parse_step_arguments(step)
+        messages.append({
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": tool_call_id,
+                "type": "function",
+                "function": {
+                    "name": tool_name,
+                    "arguments": json.dumps(arguments, ensure_ascii=False),
+                },
+            }],
+        })
+        messages.append({
+            "role": "tool",
+            "tool_call_id": tool_call_id,
+            "content": step.get("result_summary") or "",
+        })
+
+    messages.append({
+        "role": "assistant",
+        "content": record.get("display") or record.get("speak") or "",
+    })
+    return {
+        "messages": messages,
+        "meta": {
+            "intent_class": record.get("intent_class"),
+            "model": record.get("model"),
+            "cwd": record.get("cwd"),
+            "duration_ms": record.get("duration_ms"),
+            "num_steps": len(record.get("steps", [])),
+        },
+    }
+
+
+def synthesize_counter_examples() -> list[dict]:
+    examples = [
+        {
+            "messages": [
+                {"role": "user", "content": "find every TODO in the src folder"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "search_content",
+                            "arguments": json.dumps(
+                                {"pattern": "TODO", "directory": "src"},
+                                ensure_ascii=False,
+                            ),
+                        },
+                    }],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "12 matches in src/"},
+                {"role": "assistant", "content": "I found 12 TODO matches in src."},
+            ],
+            "meta": {"synthetic": True, "failure_mode": "grep_as_text"},
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "read the requirements.txt file"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "file_read",
+                            "arguments": json.dumps(
+                                {"path": "requirements.txt"},
+                                ensure_ascii=False,
+                            ),
+                        },
+                    }],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "fastapi==0.115.0\nhttpx==0.28.1"},
+                {"role": "assistant", "content": "The file contains FastAPI and httpx dependencies."},
+            ],
+            "meta": {"synthetic": True, "failure_mode": "read_file_blindspot"},
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "what branch am I on in this repo"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "shell_run",
+                            "arguments": json.dumps(
+                                {"command": "git branch --show-current"},
+                                ensure_ascii=False,
+                            ),
+                        },
+                    }],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "phase-b-local-first-consolidation"},
+                {"role": "assistant", "content": "You are on `phase-b-local-first-consolidation`."},
+            ],
+            "meta": {"synthetic": True, "failure_mode": "answers_from_memory"},
+        },
+    ]
+    return examples
+
+
+def split_examples(examples: list[dict], valid_ratio: float, seed: int) -> tuple[list[dict], list[dict]]:
+    items = list(examples)
+    random.Random(seed).shuffle(items)
+    valid_count = max(1, int(len(items) * valid_ratio)) if items else 0
+    if valid_count >= len(items) and len(items) > 1:
+        valid_count = len(items) - 1
+    valid = items[:valid_count]
+    train = items[valid_count:]
+    return train, valid
+
+
+def write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def summarize(records: list[dict], curated: list[dict]) -> dict:
+    successful = [r for r in records if is_successful_executor_record(r)]
+    return {
+        "raw_records": len(records),
+        "successful_executor_records": len(successful),
+        "models": Counter(r.get("model") for r in successful),
+        "intents": Counter(r.get("intent_class") for r in successful),
+        "step_counts": Counter(len(r.get("steps", [])) for r in successful),
+        "curated_examples": len(curated),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Curate Jarvis training.log into executor SFT JSONL.")
+    parser.add_argument("--training-log", type=Path, default=DEFAULT_TRAINING_LOG)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--valid-ratio", type=float, default=0.1)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--include-synthetic", action="store_true")
+    args = parser.parse_args()
+
+    records = load_records(args.training_log)
+    curated = [build_executor_example(r) for r in records if is_successful_executor_record(r)]
+    if args.include_synthetic:
+        curated.extend(synthesize_counter_examples())
+
+    train, valid = split_examples(curated, valid_ratio=args.valid_ratio, seed=args.seed)
+    write_jsonl(args.out_dir / "train.jsonl", train)
+    write_jsonl(args.out_dir / "valid.jsonl", valid)
+
+    summary = summarize(records, curated)
+    summary["train_examples"] = len(train)
+    summary["valid_examples"] = len(valid)
+    summary["include_synthetic"] = args.include_synthetic
+    print(json.dumps(summary, indent=2, ensure_ascii=False, default=lambda x: dict(x)))
+
+
+if __name__ == "__main__":
+    main()

--- a/jarvis-core/finetune_data/curate_classifier.py
+++ b/jarvis-core/finetune_data/curate_classifier.py
@@ -1,0 +1,230 @@
+import argparse
+import json
+import random
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from classifier_prompt import CLASSIFY_SYSTEM_PROMPT
+
+VALID_INTENTS = {"read_only", "prepare", "destructive", "complex_reasoning"}
+DEFAULT_TRAINING_LOG = Path.home() / ".jarvis" / "logs" / "training.log"
+DEFAULT_EXISTING_DIR = Path.home() / ".jarvis" / "training" / "classifier_dataset"
+DEFAULT_OUTPUT_DIR = Path.home() / ".jarvis" / "training" / "classifier_unified"
+DEFAULT_SEED_FILES = (
+    Path.home() / "Desktop" / "seeds.json",
+    Path.home() / "Desktop" / "seeds2.json",
+    Path.home() / "Desktop" / "seeds3.json",
+)
+
+DEFAULT_REASONS = {
+    "read_only": "The request can be answered using local read-only tools or local information.",
+    "prepare": "The request asks Jarvis to prepare or make a reversible change.",
+    "destructive": "The request asks for a destructive, irreversible, or approval-gated action.",
+    "complex_reasoning": "The request needs current external information or complex cloud reasoning.",
+}
+
+
+def normalize_command(command: str) -> str:
+    return " ".join(command.casefold().split())
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    rows = []
+    with path.open(encoding="utf-8") as f:
+        for lineno, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                print(f"[curate-classifier] skipping malformed JSON: {path}:{lineno}")
+    return rows
+
+
+def load_existing_examples(dataset_dir: Path) -> list[dict]:
+    examples = []
+    for path in (dataset_dir / "train.jsonl", dataset_dir / "valid.jsonl"):
+        for row in load_jsonl(path):
+            messages = row.get("messages") or []
+            if len(messages) < 2:
+                continue
+            try:
+                output = json.loads(messages[-1]["content"])
+            except (KeyError, TypeError, json.JSONDecodeError):
+                continue
+            examples.append({
+                "command": messages[-2].get("content", ""),
+                "intent_class": output.get("intent_class"),
+                "reason": output.get("reason"),
+                "source": f"existing:{path.name}",
+            })
+    return examples
+
+
+def load_seed_examples(paths: tuple[Path, ...]) -> list[dict]:
+    examples = []
+    for path in paths:
+        if not path.exists():
+            continue
+        try:
+            rows = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            print(f"[curate-classifier] skipping malformed JSON: {path}")
+            continue
+        for row in rows:
+            examples.append({
+                "command": row.get("command", ""),
+                "intent_class": row.get("expected_class"),
+                "reason": None,
+                "source": f"seed:{path.name}",
+            })
+    return examples
+
+
+def load_training_log_examples(path: Path) -> list[dict]:
+    examples = []
+    for row in load_jsonl(path):
+        examples.append({
+            "command": row.get("request", ""),
+            "intent_class": row.get("intent_class"),
+            "reason": row.get("reason"),
+            "source": f"training_log:{row.get('source') or 'interaction'}",
+        })
+    return examples
+
+
+def unify_examples(candidates: list[dict]) -> tuple[list[dict], dict]:
+    grouped = defaultdict(list)
+    rejected_invalid = 0
+    for candidate in candidates:
+        command = candidate.get("command", "").strip()
+        intent = candidate.get("intent_class")
+        if not command or intent not in VALID_INTENTS:
+            rejected_invalid += 1
+            continue
+        grouped[normalize_command(command)].append({**candidate, "command": command})
+
+    unified = []
+    conflicts = []
+    duplicate_candidates = 0
+    for normalized, group in grouped.items():
+        labels = {item["intent_class"] for item in group}
+        duplicate_candidates += len(group) - 1
+        if len(labels) != 1:
+            conflicts.append({
+                "normalized_command": normalized,
+                "labels": sorted(labels),
+                "sources": sorted({item["source"] for item in group}),
+            })
+            continue
+
+        chosen = next((item for item in group if item.get("reason")), group[0])
+        unified.append(chosen)
+
+    unified.sort(key=lambda item: normalize_command(item["command"]))
+    summary = {
+        "input_candidates": len(candidates),
+        "rejected_invalid": rejected_invalid,
+        "duplicate_candidates": duplicate_candidates,
+        "conflicting_commands": len(conflicts),
+        "conflicts": conflicts,
+    }
+    return unified, summary
+
+
+def build_classifier_example(example: dict) -> dict:
+    intent = example["intent_class"]
+    output = {
+        "can_handle_locally": intent != "complex_reasoning",
+        "intent_class": intent,
+        "reason": example.get("reason") or DEFAULT_REASONS[intent],
+    }
+    return {
+        "messages": [
+            {"role": "system", "content": CLASSIFY_SYSTEM_PROMPT},
+            {"role": "user", "content": example["command"]},
+            {"role": "assistant", "content": json.dumps(output, ensure_ascii=False)},
+        ]
+    }
+
+
+def stratified_split(examples: list[dict], valid_ratio: float, seed: int) -> tuple[list[dict], list[dict]]:
+    by_label = defaultdict(list)
+    for example in examples:
+        output = json.loads(example["messages"][-1]["content"])
+        by_label[output["intent_class"]].append(example)
+
+    rng = random.Random(seed)
+    train = []
+    valid = []
+    for label in sorted(by_label):
+        items = by_label[label]
+        rng.shuffle(items)
+        valid_count = max(1, round(len(items) * valid_ratio)) if len(items) > 1 else 0
+        valid.extend(items[:valid_count])
+        train.extend(items[valid_count:])
+    rng.shuffle(train)
+    rng.shuffle(valid)
+    return train, valid
+
+
+def write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def label_counts(examples: list[dict]) -> dict:
+    counts = Counter()
+    for example in examples:
+        output = json.loads(example["messages"][-1]["content"])
+        counts[output["intent_class"]] += 1
+    return dict(counts)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build a unified classifier dataset for MLX LoRA.")
+    parser.add_argument("--training-log", type=Path, default=DEFAULT_TRAINING_LOG)
+    parser.add_argument("--existing-dir", type=Path, default=DEFAULT_EXISTING_DIR)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--seed-files", type=Path, nargs="*", default=list(DEFAULT_SEED_FILES))
+    parser.add_argument("--valid-ratio", type=float, default=0.1)
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    candidates = [
+        *load_existing_examples(args.existing_dir),
+        *load_seed_examples(tuple(args.seed_files)),
+        *load_training_log_examples(args.training_log),
+    ]
+    unified, summary = unify_examples(candidates)
+    formatted = [build_classifier_example(example) for example in unified]
+    train, valid = stratified_split(formatted, valid_ratio=args.valid_ratio, seed=args.seed)
+
+    write_jsonl(args.out_dir / "train.jsonl", train)
+    write_jsonl(args.out_dir / "valid.jsonl", valid)
+    (args.out_dir / "summary.json").write_text(
+        json.dumps({
+            **summary,
+            "unified_examples": len(formatted),
+            "train_examples": len(train),
+            "valid_examples": len(valid),
+            "label_counts": label_counts(formatted),
+            "train_label_counts": label_counts(train),
+            "valid_label_counts": label_counts(valid),
+        }, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print((args.out_dir / "summary.json").read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    main()

--- a/jarvis-core/finetune_data/evaluate_classifier.py
+++ b/jarvis-core/finetune_data/evaluate_classifier.py
@@ -1,0 +1,142 @@
+import argparse
+import json
+import statistics
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import httpx
+
+DEFAULT_DATASET = Path.home() / ".jarvis" / "training" / "classifier_unified" / "valid.jsonl"
+DEFAULT_MODEL = "mlx-community/Qwen3-4B-Instruct-2507-4bit"
+
+
+def load_cases(path: Path) -> list[dict]:
+    cases = []
+    with path.open(encoding="utf-8") as f:
+        for lineno, line in enumerate(f, 1):
+            try:
+                row = json.loads(line)
+                messages = row["messages"]
+                expected = json.loads(messages[-1]["content"])["intent_class"]
+                cases.append({
+                    "messages": messages[:-1],
+                    "command": messages[-2]["content"],
+                    "expected": expected,
+                })
+            except (KeyError, TypeError, json.JSONDecodeError) as exc:
+                raise ValueError(f"invalid classifier case on line {lineno}: {exc}") from exc
+    return cases
+
+
+def parse_classifier_output(content: str) -> dict:
+    start = content.find("{")
+    end = content.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        raise ValueError("response did not contain a JSON object")
+    output = json.loads(content[start:end + 1])
+    if not isinstance(output, dict):
+        raise ValueError("classifier output must be a JSON object")
+    return output
+
+
+def evaluate(
+    cases: list[dict],
+    endpoint: str,
+    model: str,
+    timeout: float,
+) -> dict:
+    correct = 0
+    malformed = 0
+    latencies = []
+    expected_counts = Counter()
+    correct_counts = Counter()
+    confusion = defaultdict(Counter)
+    failures = []
+
+    with httpx.Client(timeout=timeout) as client:
+        for index, case in enumerate(cases, 1):
+            started = time.monotonic()
+            try:
+                response = client.post(
+                    f"{endpoint.rstrip('/')}/v1/chat/completions",
+                    json={
+                        "model": model,
+                        "messages": case["messages"],
+                        "temperature": 0,
+                        "max_tokens": 128,
+                        "chat_template_kwargs": {"enable_thinking": False},
+                    },
+                )
+                response.raise_for_status()
+                content = response.json()["choices"][0]["message"]["content"] or ""
+                output = parse_classifier_output(content)
+                predicted = output.get("intent_class")
+            except Exception as exc:
+                predicted = "__malformed__"
+                malformed += 1
+                content = str(exc)
+
+            elapsed_ms = (time.monotonic() - started) * 1000
+            latencies.append(elapsed_ms)
+            expected = case["expected"]
+            expected_counts[expected] += 1
+            confusion[expected][predicted] += 1
+            is_correct = predicted == expected
+            if is_correct:
+                correct += 1
+                correct_counts[expected] += 1
+            else:
+                failures.append({
+                    "command": case["command"],
+                    "expected": expected,
+                    "predicted": predicted,
+                    "response": content[:1000],
+                })
+            print(
+                f"[{index:03d}/{len(cases):03d}] "
+                f"{'OK' if is_correct else 'FAIL':<4} "
+                f"expected={expected:<17} predicted={predicted:<17} "
+                f"{elapsed_ms:.0f}ms"
+            )
+
+    per_class_accuracy = {
+        label: correct_counts[label] / count * 100
+        for label, count in sorted(expected_counts.items())
+    }
+    return {
+        "endpoint": endpoint,
+        "model": model,
+        "total": len(cases),
+        "correct": correct,
+        "accuracy_pct": correct / len(cases) * 100 if cases else 0,
+        "malformed": malformed,
+        "avg_latency_ms": statistics.mean(latencies) if latencies else 0,
+        "p50_latency_ms": statistics.median(latencies) if latencies else 0,
+        "p95_latency_ms": sorted(latencies)[min(int(len(latencies) * 0.95), len(latencies) - 1)]
+        if latencies else 0,
+        "per_class_accuracy_pct": per_class_accuracy,
+        "confusion": {expected: dict(predicted) for expected, predicted in confusion.items()},
+        "failures": failures,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Evaluate a classifier through an OpenAI-compatible endpoint.")
+    parser.add_argument("--endpoint", default="http://127.0.0.1:8090")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--dataset", type=Path, default=DEFAULT_DATASET)
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    summary = evaluate(load_cases(args.dataset), args.endpoint, args.model, args.timeout)
+    rendered = json.dumps(summary, indent=2, ensure_ascii=False)
+    print(rendered)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/jarvis-core/finetune_data/train_classifier.py
+++ b/jarvis-core/finetune_data/train_classifier.py
@@ -1,0 +1,81 @@
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+DEFAULT_MODEL = "mlx-community/Qwen3-4B-Instruct-2507-4bit"
+DEFAULT_DATA_DIR = Path.home() / ".jarvis" / "training" / "classifier_unified"
+DEFAULT_ADAPTER_PATH = Path.home() / ".jarvis" / "training" / "classifier_adapters"
+
+
+def build_command(
+    mlx_lora: str,
+    model: str,
+    data_dir: Path,
+    adapter_path: Path,
+    *,
+    smoke: bool,
+) -> list[str]:
+    command = [
+        mlx_lora,
+        "--model", model,
+        "--train",
+        "--data", str(data_dir),
+        "--fine-tune-type", "lora",
+        "--optimizer", "adamw",
+        "--mask-prompt",
+        "--iters", "1" if smoke else "600",
+        "--batch-size", "1" if smoke else "4",
+        "--num-layers", "1" if smoke else "8",
+        "--learning-rate", "1e-5",
+        "--steps-per-report", "1" if smoke else "10",
+        "--steps-per-eval", "1" if smoke else "100",
+        "--val-batches", "1" if smoke else "25",
+        "--save-every", "1" if smoke else "100",
+        "--max-seq-length", "1024",
+        "--adapter-path", str(adapter_path),
+        "--seed", "42",
+    ]
+    return command
+
+
+def validate_inputs(data_dir: Path) -> None:
+    missing = [
+        path.name
+        for path in (data_dir / "train.jsonl", data_dir / "valid.jsonl")
+        if not path.exists() or path.stat().st_size == 0
+    ]
+    if missing:
+        raise FileNotFoundError(
+            f"missing classifier dataset files in {data_dir}: {', '.join(missing)}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train the Jarvis Qwen3-4B classifier LoRA.")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR)
+    parser.add_argument("--adapter-path", type=Path, default=DEFAULT_ADAPTER_PATH)
+    parser.add_argument("--smoke", action="store_true", help="Run one iteration with one LoRA layer.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the command without running it.")
+    args = parser.parse_args()
+
+    validate_inputs(args.data_dir)
+    mlx_lora = shutil.which("mlx_lm.lora")
+    if not mlx_lora:
+        raise FileNotFoundError("mlx_lm.lora is not installed or not on PATH")
+
+    command = build_command(
+        mlx_lora,
+        args.model,
+        args.data_dir,
+        args.adapter_path,
+        smoke=args.smoke,
+    )
+    print(" ".join(command))
+    if not args.dry_run:
+        subprocess.run(command, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/jarvis-core/ollama_agent.py
+++ b/jarvis-core/ollama_agent.py
@@ -239,6 +239,9 @@ class OllamaAgent:
 
     @property
     def _chat_template_kwargs(self) -> dict | None:
+        # rapid-mlx handles chat templating internally — don't inject Ollama-specific kwargs
+        if self._config.get("ollama", {}).get("executor_rapid_mlx"):
+            return None
         return self._config.get("ollama", {}).get("executor_chat_template_kwargs")
 
     @property

--- a/jarvis-core/router.py
+++ b/jarvis-core/router.py
@@ -2,30 +2,12 @@ import json
 import logging
 import time
 import httpx
+from classifier_prompt import CLASSIFY_SYSTEM_PROMPT
 from guardrails import Guardrails
 from ollama_agent import OllamaAgent, EscalateToCloud
 from agent import Agent, claude_code_available
 
 _VALID_ROUTING_MODES = {"ollama_first", "claude_only", "ollama_only", "haiku_first", "local_first"}
-
-_CLASSIFY_SYSTEM_PROMPT = """You are a command classifier. Analyze the user request and return ONLY a JSON object — no other text.
-
-Return exactly this structure:
-{
-  "can_handle_locally": true or false,
-  "intent_class": "read_only" or "prepare" or "destructive" or "complex_reasoning",
-  "reason": "one sentence explanation"
-}
-
-Rules for can_handle_locally:
-- true: task needs only file ops, shell commands, app control, code execution, OS queries
-- false: task needs web search, current news/prices, advanced code generation, deep reasoning
-
-Rules for intent_class:
-- read_only: just reading or querying, no changes (list files, read a file, show git log, check dependencies, explain code, search a codebase)
-- prepare: will make changes the user should preview (generate code, draft text, move files)
-- destructive: deletes files, sends messages, modifies system settings, irreversible actions
-- complex_reasoning: needs web search, real-time data, or external information NOT available on this machine (news, prices, current events, remote APIs, live documentation). Git history, local files, installed packages, running processes, and codebase questions are NOT complex_reasoning — they are read_only."""
 
 
 class Router:
@@ -98,7 +80,7 @@ class Router:
                 json={
                     "model": self._classifier_model,
                     "messages": [
-                        {"role": "system", "content": _CLASSIFY_SYSTEM_PROMPT},
+                        {"role": "system", "content": CLASSIFY_SYSTEM_PROMPT},
                         {"role": "user", "content": text},
                     ],
                     "chat_template_kwargs": {"enable_thinking": False},

--- a/jarvis-core/router.py
+++ b/jarvis-core/router.py
@@ -19,6 +19,7 @@ class Router:
 
     def __init__(self, config: dict, guardrails: Guardrails):
         self._config = config
+        self._http_client = httpx.Client(timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=5.0))
         self._ollama = OllamaAgent(config=config, guardrails=guardrails)
         haiku_model = config.get("models", {}).get("haiku", "claude-haiku-4-5-20251001")
         sonnet_model = config.get("models", {}).get("sonnet", "claude-sonnet-4-6")
@@ -72,27 +73,26 @@ class Router:
         return float(self._config.get("ollama", {}).get("timeout_seconds", 30))
 
     def _classify(self, text: str) -> dict:
-        """Ask Ollama to classify intent. Returns classification dict.
+        """Ask the classifier to classify intent. Returns classification dict.
         Raises on any error — caller handles gracefully."""
-        with httpx.Client(timeout=httpx.Timeout(connect=5.0, read=self._ollama_timeout, write=30.0, pool=5.0)) as client:
-            resp = client.post(
-                f"{self._classifier_host}/v1/chat/completions",
-                json={
-                    "model": self._classifier_model,
-                    "messages": [
-                        {"role": "system", "content": CLASSIFY_SYSTEM_PROMPT},
-                        {"role": "user", "content": text},
-                    ],
-                    "chat_template_kwargs": {"enable_thinking": False},
-                },
-            )
-            resp.raise_for_status()
-            content = resp.json()["choices"][0]["message"]["content"] or ""
-            # Extract JSON robustly — model may wrap output in tags or non-Latin text
-            start, end = content.find("{"), content.rfind("}")
-            if start == -1 or end == -1:
-                raise ValueError(f"No JSON object found in classifier response: {content!r}")
-            return json.loads(content[start:end + 1])
+        resp = self._http_client.post(
+            f"{self._classifier_host}/v1/chat/completions",
+            json={
+                "model": self._classifier_model,
+                "messages": [
+                    {"role": "system", "content": CLASSIFY_SYSTEM_PROMPT},
+                    {"role": "user", "content": text},
+                ],
+                "chat_template_kwargs": {"enable_thinking": False},
+            },
+        )
+        resp.raise_for_status()
+        content = resp.json()["choices"][0]["message"]["content"] or ""
+        # Extract JSON robustly — model may wrap output in tags or non-Latin text
+        start, end = content.find("{"), content.rfind("}")
+        if start == -1 or end == -1:
+            raise ValueError(f"No JSON object found in classifier response: {content!r}")
+        return json.loads(content[start:end + 1])
 
     def resume(self, command_id: str, step_callback=None) -> dict | None:
         """Continue a run paused for approval. Returns the annotated final result,
@@ -241,10 +241,6 @@ class Router:
         assistant_text = result.get("display") or result.get("speak") or ""
         if not assistant_text:
             return
-        steps = result.get("steps") or []
-        if steps:
-            tools_used = ", ".join(s["tool"] for s in steps)
-            assistant_text = f"{assistant_text}\n\n[Tools used: {tools_used}]"
         self._history.extend([
             {"role": "user", "content": user_text},
             {"role": "assistant", "content": assistant_text},

--- a/jarvis-core/server.py
+++ b/jarvis-core/server.py
@@ -73,9 +73,12 @@ def _ensure_mlx_server_running(config: dict) -> None:
     ollama_cfg = config.get("ollama", {})
     if ollama_cfg.get("routing_mode") != "local_first":
         return
+    base_host = ollama_cfg.get("host", "http://localhost:11434")
     executor_host = ollama_cfg.get("executor_host", "")
     executor_model = ollama_cfg.get("executor_model", "")
     if not executor_host or not executor_model:
+        return
+    if executor_host == base_host:
         return
 
     try:
@@ -190,6 +193,11 @@ def reset_conversation():
 
 def _log_command(req: "CommandRequest", start: float, result: dict) -> None:
     """Log command analytics and training data."""
+    _log_command_result(req, start, result, resumed=False)
+
+
+def _log_command_result(req: "CommandRequest", start: float, result: dict, *, resumed: bool) -> None:
+    """Log command analytics and training data for both fresh and resumed runs."""
     duration_ms = int((time.time() - start) * 1000)
     if _loggers:
         _loggers["commands"].info(
@@ -201,6 +209,7 @@ def _log_command(req: "CommandRequest", start: float, result: dict) -> None:
             "has_approval_required": "approval_required" in result,
             "agent": result.get("_agent"),
             "model": result.get("_model"),
+            "resumed": resumed,
             "escalated": result.get("_escalated"),
             "escalation_reason": result.get("_escalation_reason"),
             "agent_response_ms": result.get("_response_ms"),
@@ -386,6 +395,9 @@ async def approve(req: ApprovalRequest):
     # and continue) instead of having the client replay the whole command. Falls back
     # to reissue_command when there is no paused state (e.g. after a server restart).
     if req.command_id and approval_store.has(req.command_id):
+        paused_entry = approval_store.get(req.command_id) or {}
+        paused_meta = paused_entry.get("meta", {})
+        start = time.time()
         loop = asyncio.get_running_loop()
         try:
             result = await loop.run_in_executor(None, lambda: _pipeline.resume(req.command_id))
@@ -398,6 +410,12 @@ async def approve(req: ApprovalRequest):
                 _guardrails.clear_session_trusts()
         if result is None or result.get("busy"):
             return {"acknowledged": True, "next_action": "reissue_command"}
+        resume_req = CommandRequest(
+            text=paused_meta.get("user_text", ""),
+            cwd=paused_meta.get("cwd"),
+            source=paused_meta.get("source", "approval"),
+        )
+        _log_command_result(resume_req, start, result, resumed=True)
         return {"acknowledged": True, "next_action": "resumed", **result}
 
     # No paused state — client re-issues the original command (category now trusted).

--- a/jarvis-core/server.py
+++ b/jarvis-core/server.py
@@ -111,12 +111,54 @@ def _ensure_mlx_server_running(config: dict) -> None:
     logging.info("[Jarvis] mlx_lm.server started: model=%s port=%d", executor_model, port)
 
 
+def _ensure_classifier_server_running(config: dict) -> None:
+    """Start mlx_lm.server for the classifier if it runs on a separate host and isn't already up."""
+    ollama_cfg = config.get("ollama", {})
+    base_host = ollama_cfg.get("host", "http://localhost:11434")
+    classifier_host = ollama_cfg.get("classifier_host", "")
+    classifier_model = ollama_cfg.get("classifier_model", "")
+    if not classifier_host or not classifier_model:
+        return
+    if classifier_host == base_host:
+        return  # classifier is on Ollama, no MLX server needed
+
+    try:
+        r = httpx.get(f"{classifier_host}/v1/models", timeout=2)
+        if r.status_code < 500:
+            return  # already running
+    except Exception:
+        pass  # not running — start it
+
+    mlx_bin = (
+        shutil.which("mlx_lm.server")
+        or (p if (p := "/opt/homebrew/bin/mlx_lm.server") and os.path.exists(p) else None)
+    )
+    if not mlx_bin:
+        logging.warning("[Jarvis] mlx_lm.server binary not found — skipping classifier auto-start")
+        return
+
+    from urllib.parse import urlparse
+    parsed = urlparse(classifier_host)
+    port = parsed.port or 8090
+
+    cmd = [mlx_bin, "--model", classifier_model, "--port", str(port)]
+
+    adapter_path = ollama_cfg.get("classifier_adapter_path", "")
+    if adapter_path and os.path.exists(adapter_path):
+        cmd += ["--adapter-path", adapter_path]
+
+    subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    logging.info("[Jarvis] mlx_lm.server (classifier) started: model=%s port=%d adapter=%s",
+                 classifier_model, port, adapter_path or "none")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     global _pipeline, _loggers, _guardrails
     config = cfg_module.load()
     _ensure_ollama_running()
     _ensure_mlx_server_running(config)
+    _ensure_classifier_server_running(config)
     alert_bus.set_loop(asyncio.get_running_loop())
     _pipeline, _loggers, _guardrails, store = load_dependencies()
     scheduler = Scheduler(store=store, pipeline=_pipeline)

--- a/jarvis-core/server.py
+++ b/jarvis-core/server.py
@@ -68,8 +68,9 @@ def _ensure_ollama_running() -> None:
     logging.info("[Jarvis] ollama serve started via %s", ollama_bin)
 
 
-def _ensure_mlx_server_running(config: dict) -> None:
-    """Start mlx_lm.server in the background if local_first mode is active and it isn't already running."""
+def _ensure_executor_server_running(config: dict) -> None:
+    """Start the executor inference server if local_first mode is active and it isn't already running.
+    Uses rapid-mlx when executor_rapid_mlx=True, mlx_lm.server otherwise."""
     ollama_cfg = config.get("ollama", {})
     if ollama_cfg.get("routing_mode") != "local_first":
         return
@@ -88,27 +89,40 @@ def _ensure_mlx_server_running(config: dict) -> None:
     except Exception:
         pass  # not running — start it
 
-    mlx_bin = (
-        shutil.which("mlx_lm.server")
-        or (p if (p := "/opt/homebrew/bin/mlx_lm.server") and os.path.exists(p) else None)
-    )
-    if not mlx_bin:
-        logging.warning("[Jarvis] mlx_lm.server binary not found — skipping auto-start")
-        return
-
     from urllib.parse import urlparse
     parsed = urlparse(executor_host)
-    port = parsed.port or 8090
+    port = parsed.port or 8093
 
-    chat_template_kwargs = ollama_cfg.get("executor_chat_template_kwargs", {})
-    chat_template_args = json.dumps(chat_template_kwargs) if chat_template_kwargs else None
-
-    cmd = [mlx_bin, "--model", executor_model, "--port", str(port)]
-    if chat_template_args:
-        cmd += ["--chat-template-args", chat_template_args]
-
-    subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    logging.info("[Jarvis] mlx_lm.server started: model=%s port=%d", executor_model, port)
+    if ollama_cfg.get("executor_rapid_mlx"):
+        rapid_bin = (
+            shutil.which("rapid-mlx")
+            or (p if (p := "/opt/homebrew/bin/rapid-mlx") and os.path.exists(p) else None)
+        )
+        if not rapid_bin:
+            logging.warning("[Jarvis] rapid-mlx binary not found — skipping executor auto-start")
+            return
+        cmd = [
+            rapid_bin, "serve", executor_model,
+            "--port", str(port), "--host", "127.0.0.1",
+            "--enable-auto-tool-choice", "--tool-call-parser", "qwen3_coder_xml",
+        ]
+        subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        logging.info("[Jarvis] rapid-mlx executor started: model=%s port=%d", executor_model, port)
+    else:
+        mlx_bin = (
+            shutil.which("mlx_lm.server")
+            or (p if (p := "/opt/homebrew/bin/mlx_lm.server") and os.path.exists(p) else None)
+        )
+        if not mlx_bin:
+            logging.warning("[Jarvis] mlx_lm.server binary not found — skipping executor auto-start")
+            return
+        chat_template_kwargs = ollama_cfg.get("executor_chat_template_kwargs", {})
+        chat_template_args = json.dumps(chat_template_kwargs) if chat_template_kwargs else None
+        cmd = [mlx_bin, "--model", executor_model, "--port", str(port)]
+        if chat_template_args:
+            cmd += ["--chat-template-args", chat_template_args]
+        subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        logging.info("[Jarvis] mlx_lm.server executor started: model=%s port=%d", executor_model, port)
 
 
 def _ensure_classifier_server_running(config: dict) -> None:
@@ -157,7 +171,7 @@ async def lifespan(app: FastAPI):
     global _pipeline, _loggers, _guardrails
     config = cfg_module.load()
     _ensure_ollama_running()
-    _ensure_mlx_server_running(config)
+    _ensure_executor_server_running(config)
     _ensure_classifier_server_running(config)
     alert_bus.set_loop(asyncio.get_running_loop())
     _pipeline, _loggers, _guardrails, store = load_dependencies()

--- a/jarvis-core/tests/test_agent.py
+++ b/jarvis-core/tests/test_agent.py
@@ -84,6 +84,22 @@ def test_format_response_no_voice_tag_falls_back_to_heuristic():
     assert result["display"] == long_text
 
 
+def test_format_response_does_not_split_on_decimal_point():
+    """Heuristic must not split 'Python version 3.5' into 'Python version 3'."""
+    # The split-on-'.' bug only manifests when text before the first '.' is 11–140 chars.
+    # "Python version 3" is 16 chars → currently produces speak "Python version 3."
+    text = "Python version 3.5 is now installed on your system. " + "A" * 120
+    result = format_response(text, tool_calls_made=["shell_run"])
+    assert "3.5" in result["speak"], f"decimal was split; speak={result['speak']!r}"
+
+
+def test_format_response_splits_on_real_sentence_boundary():
+    """Heuristic should produce first sentence when text is >= 150 chars."""
+    text = "The build succeeded. " + "A" * 140
+    result = format_response(text, tool_calls_made=["shell_run"])
+    assert result["speak"] == "The build succeeded."
+
+
 def test_web_fetch_empty_body_returns_empty_string_not_error():
     """web_fetch with empty string body should return '' not 'error=None'."""
     agent = make_agent()
@@ -108,14 +124,36 @@ def test_execute_tool_shell_run_uses_cwd():
     agent = make_agent()
     with patch.object(agent._shell, "run", return_value={"exit_code": 0, "stdout": "ok", "stderr": "", "error": None}) as mock_run:
         execute_tool("shell_run", {"command": "pytest"}, agent._shell, agent._web, agent._code, agent._macos, agent._guardrails, default_cwd="/my/project")
-    mock_run.assert_called_once_with("pytest", cwd="/my/project")
+    _, kwargs = mock_run.call_args
+    assert kwargs["cwd"] == "/my/project"
 
 
 def test_execute_tool_cwd_override_from_input():
     agent = make_agent()
     with patch.object(agent._shell, "run", return_value={"exit_code": 0, "stdout": "", "stderr": "", "error": None}) as mock_run:
         execute_tool("shell_run", {"command": "ls", "cwd": "/override"}, agent._shell, agent._web, agent._code, agent._macos, agent._guardrails, default_cwd="/default")
-    mock_run.assert_called_once_with("ls", cwd="/override")
+    _, kwargs = mock_run.call_args
+    assert kwargs["cwd"] == "/override"
+
+
+def test_execute_tool_shell_run_passes_timeout_when_provided():
+    """dispatch passes the timeout from tool_input through to shell.run."""
+    agent = make_agent()
+    with patch.object(agent._shell, "run", return_value={"exit_code": 0, "stdout": "", "stderr": "", "error": None}) as mock_run:
+        execute_tool("shell_run", {"command": "make build", "timeout": 120},
+                     agent._shell, agent._web, agent._code, agent._macos, agent._guardrails, default_cwd=None)
+    _, kwargs = mock_run.call_args
+    assert kwargs["timeout"] == 120
+
+
+def test_execute_tool_shell_run_caps_timeout_at_maximum():
+    """dispatch caps oversized timeouts to prevent abuse."""
+    agent = make_agent()
+    with patch.object(agent._shell, "run", return_value={"exit_code": 0, "stdout": "", "stderr": "", "error": None}) as mock_run:
+        execute_tool("shell_run", {"command": "sleep 9999", "timeout": 99999},
+                     agent._shell, agent._web, agent._code, agent._macos, agent._guardrails, default_cwd=None)
+    _, kwargs = mock_run.call_args
+    assert kwargs["timeout"] <= 600
 
 
 def test_execute_tool_run_code_multi_language():

--- a/jarvis-core/tests/test_command_pipeline.py
+++ b/jarvis-core/tests/test_command_pipeline.py
@@ -51,10 +51,26 @@ def test_submit_marks_command_completed(pipeline):
 
 # ── busy lock ─────────────────────────────────────────────────────────────────
 
+def test_submit_while_lock_held_returns_busy(pipeline, mock_router):
+    """Submit returns busy immediately when the threading lock is held (thread-safe)."""
+    pipeline._lock.acquire()
+    pipeline._current_command_id = "running-id"
+    try:
+        result = pipeline.submit("another command", cwd=None, source="hotkey")
+    finally:
+        pipeline._lock.release()
+    assert result.get("busy") is True
+    assert result.get("command_id") == "running-id"
+    mock_router.process.assert_not_called()
+
+
 def test_submit_while_busy_returns_busy_response(pipeline, mock_router):
-    pipeline._executing = True
+    pipeline._lock.acquire()
     pipeline._current_command_id = "fake-id"
-    result = pipeline.submit("another command", cwd=None, source="hotkey")
+    try:
+        result = pipeline.submit("another command", cwd=None, source="hotkey")
+    finally:
+        pipeline._lock.release()
     assert result.get("busy") is True
     assert result.get("command_id") == "fake-id"
     mock_router.process.assert_not_called()
@@ -62,20 +78,20 @@ def test_submit_while_busy_returns_busy_response(pipeline, mock_router):
 
 def test_submit_releases_lock_after_completion(pipeline):
     pipeline.submit("do something", cwd=None, source="hotkey")
-    assert pipeline._executing is False
+    assert not pipeline._lock.locked()
 
 
 def test_submit_releases_lock_on_router_exception(pipeline, mock_router):
     mock_router.process.side_effect = RuntimeError("boom")
     with pytest.raises(RuntimeError):
         pipeline.submit("bad command", cwd=None, source="hotkey")
-    assert pipeline._executing is False
+    assert not pipeline._lock.locked()
 
 
 # ── cancel ────────────────────────────────────────────────────────────────────
 
 def test_cancel_executing_command_releases_lock(pipeline):
-    pipeline._executing = True
+    pipeline._lock.acquire()
     pipeline._current_command_id = "abc"
     cmd = pipeline._create_command("running task", cwd=None, source="hotkey")
     cmd.id = "abc"
@@ -84,7 +100,7 @@ def test_cancel_executing_command_releases_lock(pipeline):
 
     result = pipeline.cancel("abc")
     assert result["cancelled"] is True
-    assert pipeline._executing is False
+    assert not pipeline._lock.locked()
     assert pipeline._registry["abc"].status == CommandStatus.CANCELLED
 
 
@@ -96,11 +112,11 @@ def test_cancel_unknown_id_returns_not_found(pipeline):
 # ── abort ─────────────────────────────────────────────────────────────────────
 
 def test_abort_force_releases_lock(pipeline):
-    pipeline._executing = True
+    pipeline._lock.acquire()
     pipeline._current_command_id = "stuck"
     result = pipeline.abort()
     assert result["lock_released"] is True
-    assert pipeline._executing is False
+    assert not pipeline._lock.locked()
 
 
 # ── registry ──────────────────────────────────────────────────────────────────

--- a/jarvis-core/tests/test_config.py
+++ b/jarvis-core/tests/test_config.py
@@ -171,3 +171,18 @@ def test_step_voice_default_is_false():
     """narration.step_voice defaults to False."""
     from config import DEFAULTS
     assert DEFAULTS["narration"]["step_voice"] is False
+
+
+def test_classifier_adapter_path_default_is_empty():
+    from config import DEFAULTS
+    assert DEFAULTS["ollama"]["classifier_adapter_path"] == ""
+
+
+def test_classifier_adapter_path_loads_from_file(tmp_path, monkeypatch):
+    monkeypatch.setattr("config.CONFIG_PATH", tmp_path / "config.json")
+    (tmp_path / "config.json").write_text(json.dumps({
+        "ollama": {"classifier_adapter_path": "/some/adapter"}
+    }))
+    cfg = config.load()
+    assert cfg["ollama"]["classifier_adapter_path"] == "/some/adapter"
+    assert cfg["ollama"]["classifier_host"] == "http://127.0.0.1:8090"  # default preserved

--- a/jarvis-core/tests/test_config.py
+++ b/jarvis-core/tests/test_config.py
@@ -70,7 +70,9 @@ def test_defaults_include_ollama_block(tmp_path, monkeypatch):
     cfg = config.load()
     assert "ollama" in cfg
     assert cfg["ollama"]["host"] == "http://localhost:11434"
-    assert cfg["ollama"]["model"] == "qwen35-opus-jarvis"
+    assert cfg["ollama"]["model"] == "qwen3.6:35b-a3b"
+    assert cfg["ollama"]["executor_host"] == "http://localhost:11434"
+    assert cfg["ollama"]["executor_model"] == "qwen3.6:35b-a3b"
     assert cfg["ollama"]["classifier_model"] == "mlx-community/Qwen3-4B-Instruct-2507-4bit"
     assert cfg["ollama"]["routing_mode"] == "local_first"
     assert cfg["ollama"]["timeout_seconds"] == 300

--- a/jarvis-core/tests/test_config.py
+++ b/jarvis-core/tests/test_config.py
@@ -71,8 +71,9 @@ def test_defaults_include_ollama_block(tmp_path, monkeypatch):
     assert "ollama" in cfg
     assert cfg["ollama"]["host"] == "http://localhost:11434"
     assert cfg["ollama"]["model"] == "qwen3.6:35b-a3b"
-    assert cfg["ollama"]["executor_host"] == "http://localhost:11434"
-    assert cfg["ollama"]["executor_model"] == "qwen3.6:35b-a3b"
+    assert cfg["ollama"]["executor_host"] == "http://127.0.0.1:8093"
+    assert cfg["ollama"]["executor_model"] == "mlx-community/Qwen3.6-35B-A3B-4bit"
+    assert cfg["ollama"]["executor_rapid_mlx"] is True
     assert cfg["ollama"]["classifier_model"] == "mlx-community/Qwen3-4B-Instruct-2507-4bit"
     assert cfg["ollama"]["routing_mode"] == "local_first"
     assert cfg["ollama"]["timeout_seconds"] == 300

--- a/jarvis-core/tests/test_curate.py
+++ b/jarvis-core/tests/test_curate.py
@@ -1,0 +1,83 @@
+import json
+
+from finetune_data.curate import (
+    build_executor_example,
+    is_successful_executor_record,
+    parse_step_arguments,
+    split_examples,
+    synthesize_counter_examples,
+)
+
+
+def test_is_successful_executor_record_requires_model_steps_and_response():
+    record = {
+        "request": "read README",
+        "intent_class": "read_only",
+        "model": "qwen3.6:35b-a3b",
+        "steps": [{"tool": "file_read", "input_summary": "{'path': 'README.md'}", "result_summary": "docs"}],
+        "display": "Here is the README.",
+        "speak": "Here is the README.",
+    }
+    assert is_successful_executor_record(record) is True
+
+    assert is_successful_executor_record({**record, "model": None}) is False
+    assert is_successful_executor_record({**record, "steps": []}) is False
+    assert is_successful_executor_record({**record, "display": None, "speak": None}) is False
+
+
+def test_is_successful_executor_record_filters_known_failures():
+    record = {
+        "request": "do something",
+        "intent_class": "prepare",
+        "model": "qwen3.6:35b-a3b",
+        "steps": [{"tool": "shell_run", "input_summary": "{'command': 'echo hi'}", "result_summary": "hi"}],
+        "display": "I ran out of steps while trying to finish this.",
+        "speak": "I ran out of steps while trying to finish this.",
+    }
+    assert is_successful_executor_record(record) is False
+
+
+def test_parse_step_arguments_uses_literal_eval_for_dict_strings():
+    args = parse_step_arguments({"input_summary": "{'query': 'current weather Netanya Israel'}"})
+    assert args == {"query": "current weather Netanya Israel"}
+
+
+def test_build_executor_example_creates_tool_call_messages():
+    record = {
+        "request": "read README",
+        "intent_class": "read_only",
+        "model": "claude-haiku-4-5-20251001",
+        "cwd": None,
+        "duration_ms": 1234,
+        "steps": [
+            {
+                "tool": "file_read",
+                "input_summary": "{'path': 'README.md'}",
+                "result_summary": "# Project",
+            }
+        ],
+        "display": "The README starts with Project.",
+        "speak": "The README starts with Project.",
+    }
+    example = build_executor_example(record)
+    assert example["messages"][0] == {"role": "user", "content": "read README"}
+    assert example["messages"][1]["tool_calls"][0]["function"]["name"] == "file_read"
+    assert json.loads(example["messages"][1]["tool_calls"][0]["function"]["arguments"]) == {"path": "README.md"}
+    assert example["messages"][-1]["content"] == "The README starts with Project."
+
+
+def test_split_examples_keeps_non_empty_train_when_possible():
+    items = [{"messages": [{"role": "user", "content": str(i)}]} for i in range(3)]
+    train, valid = split_examples(items, valid_ratio=0.5, seed=42)
+    assert len(train) == 2
+    assert len(valid) == 1
+
+
+def test_synthesize_counter_examples_covers_known_failure_modes():
+    examples = synthesize_counter_examples()
+    failure_modes = {example["meta"]["failure_mode"] for example in examples}
+    assert failure_modes == {
+        "grep_as_text",
+        "read_file_blindspot",
+        "answers_from_memory",
+    }

--- a/jarvis-core/tests/test_curate_classifier.py
+++ b/jarvis-core/tests/test_curate_classifier.py
@@ -1,0 +1,80 @@
+import json
+
+from classifier_prompt import CLASSIFY_SYSTEM_PROMPT
+from finetune_data.curate_classifier import (
+    build_classifier_example,
+    normalize_command,
+    stratified_split,
+    unify_examples,
+)
+
+
+def test_normalize_command_is_case_and_whitespace_insensitive():
+    assert normalize_command("  Show   Git STATUS ") == "show git status"
+
+
+def test_unify_examples_deduplicates_matching_labels():
+    examples, summary = unify_examples([
+        {"command": "show git status", "intent_class": "read_only", "reason": None, "source": "seed"},
+        {"command": " Show  Git Status ", "intent_class": "read_only", "reason": "Local query.", "source": "log"},
+    ])
+    assert len(examples) == 1
+    assert examples[0]["reason"] == "Local query."
+    assert summary["duplicate_candidates"] == 1
+    assert summary["conflicting_commands"] == 0
+
+
+def test_unify_examples_skips_conflicting_labels():
+    examples, summary = unify_examples([
+        {"command": "delete build", "intent_class": "destructive", "reason": None, "source": "seed"},
+        {"command": "delete build", "intent_class": "prepare", "reason": None, "source": "log"},
+    ])
+    assert examples == []
+    assert summary["conflicting_commands"] == 1
+    assert summary["conflicts"][0]["labels"] == ["destructive", "prepare"]
+
+
+def test_build_classifier_example_matches_production_contract():
+    example = build_classifier_example({
+        "command": "show git status",
+        "intent_class": "read_only",
+        "reason": None,
+        "source": "test",
+    })
+    assert example["messages"][0] == {"role": "system", "content": CLASSIFY_SYSTEM_PROMPT}
+    output = json.loads(example["messages"][-1]["content"])
+    assert output["can_handle_locally"] is True
+    assert output["intent_class"] == "read_only"
+    assert set(output) == {"can_handle_locally", "intent_class", "reason"}
+
+
+def test_build_classifier_example_marks_complex_reasoning_non_local():
+    example = build_classifier_example({
+        "command": "find today's stock price",
+        "intent_class": "complex_reasoning",
+        "reason": None,
+        "source": "test",
+    })
+    output = json.loads(example["messages"][-1]["content"])
+    assert output["can_handle_locally"] is False
+
+
+def test_stratified_split_keeps_every_label_in_validation():
+    examples = []
+    for label in ("read_only", "prepare", "destructive", "complex_reasoning"):
+        for index in range(10):
+            examples.append(build_classifier_example({
+                "command": f"{label} example {index}",
+                "intent_class": label,
+                "reason": None,
+                "source": "test",
+            }))
+
+    train, valid = stratified_split(examples, valid_ratio=0.1, seed=42)
+    valid_labels = {
+        json.loads(example["messages"][-1]["content"])["intent_class"]
+        for example in valid
+    }
+    assert len(train) == 36
+    assert len(valid) == 4
+    assert valid_labels == {"read_only", "prepare", "destructive", "complex_reasoning"}

--- a/jarvis-core/tests/test_evaluate_classifier.py
+++ b/jarvis-core/tests/test_evaluate_classifier.py
@@ -1,0 +1,46 @@
+import json
+
+from finetune_data.evaluate_classifier import load_cases, parse_classifier_output
+
+
+def test_parse_classifier_output_extracts_wrapped_json():
+    output = parse_classifier_output(
+        'thinking first\n{"can_handle_locally": true, "intent_class": "read_only", "reason": "local"}'
+    )
+    assert output["intent_class"] == "read_only"
+
+
+def test_parse_classifier_output_rejects_missing_json():
+    try:
+        parse_classifier_output("read_only")
+    except ValueError as exc:
+        assert "JSON object" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_load_cases_uses_assistant_output_as_expected_label(tmp_path):
+    path = tmp_path / "valid.jsonl"
+    path.write_text(json.dumps({
+        "messages": [
+            {"role": "system", "content": "classify"},
+            {"role": "user", "content": "show git status"},
+            {
+                "role": "assistant",
+                "content": json.dumps({
+                    "can_handle_locally": True,
+                    "intent_class": "read_only",
+                    "reason": "local",
+                }),
+            },
+        ]
+    }) + "\n")
+    cases = load_cases(path)
+    assert cases == [{
+        "messages": [
+            {"role": "system", "content": "classify"},
+            {"role": "user", "content": "show git status"},
+        ],
+        "command": "show git status",
+        "expected": "read_only",
+    }]

--- a/jarvis-core/tests/test_router.py
+++ b/jarvis-core/tests/test_router.py
@@ -383,10 +383,10 @@ def test_resume_invokes_stored_resumer_and_annotates(haiku_router):
     assert not approval_store.has("c1")  # popped
 
 
-def test_default_executor_model_is_qwen35_opus_jarvis():
-    """Default ollama executor model should be qwen35-opus-jarvis."""
+def test_default_base_ollama_model_is_qwen36():
+    """Default base Ollama model should align with the selected Qwen executor."""
     from config import DEFAULTS
-    assert DEFAULTS["ollama"]["model"] == "qwen35-opus-jarvis"
+    assert DEFAULTS["ollama"]["model"] == "qwen3.6:35b-a3b"
 
 
 def test_classifier_model_in_defaults():

--- a/jarvis-core/tests/test_router.py
+++ b/jarvis-core/tests/test_router.py
@@ -403,8 +403,8 @@ def test_local_first_annotates_result_with_executor_model_name(local_first_route
 
 # ── history tool summary ──────────────────────────────────────────────────────
 
-def test_history_includes_tools_used_when_steps_present(haiku_router, mock_haiku_agent):
-    """Assistant history entry appends [Tools used: ...] when steps are present."""
+def test_history_does_not_include_tools_used_annotation(haiku_router, mock_haiku_agent):
+    """History must never contain [Tools used: ...] — teaching the model to emit it."""
     mock_haiku_agent.run.return_value = {
         "speak": "Done.", "display": "Done.",
         "steps": [
@@ -418,7 +418,7 @@ def test_history_includes_tools_used_when_steps_present(haiku_router, mock_haiku
         haiku_router.process("fetch github issues")
 
     assistant_msg = haiku_router._history[-1]["content"]
-    assert "[Tools used: web_fetch, run_code]" in assistant_msg
+    assert "[Tools used:" not in assistant_msg
 
 
 def test_history_no_tools_suffix_when_no_steps(haiku_router, mock_haiku_agent):
@@ -433,3 +433,14 @@ def test_history_no_tools_suffix_when_no_steps(haiku_router, mock_haiku_agent):
 
     assistant_msg = haiku_router._history[-1]["content"]
     assert "[Tools used:" not in assistant_msg
+
+
+# ── classifier shared http client ─────────────────────────────────────────────
+
+def test_classify_reuses_shared_http_client(config):
+    """Router._classify must use a shared httpx.Client, not create a new one each call."""
+    config["ollama"]["routing_mode"] = "local_first"
+    guardrails = Guardrails(config)
+    r = Router(config=config, guardrails=guardrails)
+    assert hasattr(r, "_http_client"), "Router must have a shared _http_client"
+    assert r._http_client is not None

--- a/jarvis-core/tests/test_server.py
+++ b/jarvis-core/tests/test_server.py
@@ -201,7 +201,7 @@ def test_command_logs_agent_analytics(client_and_agent):
     assert analytics_payload["agent_response_ms"] == 800
 
 
-def test_ensure_mlx_server_running_skips_when_executor_uses_ollama_host(client_and_agent):
+def test_ensure_executor_server_running_skips_when_executor_uses_ollama_host(client_and_agent):
     import server as srv
 
     cfg = {
@@ -213,7 +213,7 @@ def test_ensure_mlx_server_running_skips_when_executor_uses_ollama_host(client_a
         }
     }
     with patch("server.subprocess.Popen") as mock_popen:
-        srv._ensure_mlx_server_running(cfg)
+        srv._ensure_executor_server_running(cfg)
     mock_popen.assert_not_called()
 
 

--- a/jarvis-core/tests/test_server.py
+++ b/jarvis-core/tests/test_server.py
@@ -217,6 +217,107 @@ def test_ensure_mlx_server_running_skips_when_executor_uses_ollama_host(client_a
     mock_popen.assert_not_called()
 
 
+def test_ensure_classifier_server_running_skips_when_uses_ollama_host(client_and_agent):
+    import server as srv
+
+    cfg = {
+        "ollama": {
+            "host": "http://localhost:11434",
+            "classifier_host": "http://localhost:11434",
+            "classifier_model": "some-model",
+        }
+    }
+    with patch("server.subprocess.Popen") as mock_popen:
+        srv._ensure_classifier_server_running(cfg)
+    mock_popen.assert_not_called()
+
+
+def test_ensure_classifier_server_running_starts_server_without_adapter(client_and_agent):
+    import server as srv
+
+    cfg = {
+        "ollama": {
+            "host": "http://localhost:11434",
+            "classifier_host": "http://127.0.0.1:8090",
+            "classifier_model": "mlx-community/Qwen3-4B-Instruct-2507-4bit",
+            "classifier_adapter_path": "",
+        }
+    }
+    with patch("server.httpx.get", side_effect=Exception("not running")), \
+         patch("server.shutil.which", return_value="/usr/local/bin/mlx_lm.server"), \
+         patch("server.subprocess.Popen") as mock_popen:
+        srv._ensure_classifier_server_running(cfg)
+
+    call_args = mock_popen.call_args[0][0]
+    assert "--model" in call_args
+    assert "mlx-community/Qwen3-4B-Instruct-2507-4bit" in call_args
+    assert "--port" in call_args
+    assert "8090" in call_args
+    assert "--adapter-path" not in call_args
+
+
+def test_ensure_classifier_server_running_includes_adapter_path_when_configured(client_and_agent, tmp_path):
+    import server as srv
+
+    adapter_path = str(tmp_path / "classifier_adapters")
+    (tmp_path / "classifier_adapters").mkdir()
+
+    cfg = {
+        "ollama": {
+            "host": "http://localhost:11434",
+            "classifier_host": "http://127.0.0.1:8090",
+            "classifier_model": "mlx-community/Qwen3-4B-Instruct-2507-4bit",
+            "classifier_adapter_path": adapter_path,
+        }
+    }
+    with patch("server.httpx.get", side_effect=Exception("not running")), \
+         patch("server.shutil.which", return_value="/usr/local/bin/mlx_lm.server"), \
+         patch("server.subprocess.Popen") as mock_popen:
+        srv._ensure_classifier_server_running(cfg)
+
+    call_args = mock_popen.call_args[0][0]
+    assert "--adapter-path" in call_args
+    assert adapter_path in call_args
+
+
+def test_ensure_classifier_server_running_skips_adapter_path_when_dir_missing(client_and_agent, tmp_path):
+    import server as srv
+
+    cfg = {
+        "ollama": {
+            "host": "http://localhost:11434",
+            "classifier_host": "http://127.0.0.1:8090",
+            "classifier_model": "mlx-community/Qwen3-4B-Instruct-2507-4bit",
+            "classifier_adapter_path": str(tmp_path / "nonexistent_adapters"),
+        }
+    }
+    with patch("server.httpx.get", side_effect=Exception("not running")), \
+         patch("server.shutil.which", return_value="/usr/local/bin/mlx_lm.server"), \
+         patch("server.subprocess.Popen") as mock_popen:
+        srv._ensure_classifier_server_running(cfg)
+
+    call_args = mock_popen.call_args[0][0]
+    assert "--adapter-path" not in call_args
+
+
+def test_ensure_classifier_server_running_skips_if_already_running(client_and_agent):
+    import server as srv
+
+    cfg = {
+        "ollama": {
+            "host": "http://localhost:11434",
+            "classifier_host": "http://127.0.0.1:8090",
+            "classifier_model": "mlx-community/Qwen3-4B-Instruct-2507-4bit",
+        }
+    }
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    with patch("server.httpx.get", return_value=mock_resp), \
+         patch("server.subprocess.Popen") as mock_popen:
+        srv._ensure_classifier_server_running(cfg)
+    mock_popen.assert_not_called()
+
+
 def test_approve_resumed_run_logs_analytics(client_and_agent):
     import approval_store
     import logger as logger_module

--- a/jarvis-core/tests/test_server.py
+++ b/jarvis-core/tests/test_server.py
@@ -201,6 +201,54 @@ def test_command_logs_agent_analytics(client_and_agent):
     assert analytics_payload["agent_response_ms"] == 800
 
 
+def test_ensure_mlx_server_running_skips_when_executor_uses_ollama_host(client_and_agent):
+    import server as srv
+
+    cfg = {
+        "ollama": {
+            "routing_mode": "local_first",
+            "host": "http://localhost:11434",
+            "executor_host": "http://localhost:11434",
+            "executor_model": "qwen3.6:35b-a3b",
+        }
+    }
+    with patch("server.subprocess.Popen") as mock_popen:
+        srv._ensure_mlx_server_running(cfg)
+    mock_popen.assert_not_called()
+
+
+def test_approve_resumed_run_logs_analytics(client_and_agent):
+    import approval_store
+    import logger as logger_module
+
+    approval_store.clear()
+    client, _, _ = client_and_agent
+    approval_store.register(
+        "cmd-x",
+        lambda step_callback=None: {},
+        {"user_text": "delete temp file", "agent": "claude", "model": "m"},
+    )
+    with patch("server._pipeline") as mock_pipeline, \
+         patch.object(logger_module, "log_analytics") as mock_log_analytics:
+        mock_pipeline.resume.return_value = {
+            "speak": "done", "display": "done", "steps": [],
+            "_agent": "claude", "_model": "claude-sonnet-4-6",
+            "_escalated": False, "_escalation_reason": None, "_response_ms": 123,
+        }
+        resp = client.post("/approve", json={
+            "tool_use_id": "t", "approved": True, "command_id": "cmd-x",
+        })
+
+    assert resp.status_code == 200
+    assert resp.json()["next_action"] == "resumed"
+    mock_log_analytics.assert_called_once()
+    analytics_payload = mock_log_analytics.call_args.args[2]
+    assert analytics_payload["agent"] == "claude"
+    assert analytics_payload["model"] == "claude-sonnet-4-6"
+    assert analytics_payload["resumed"] is True
+    approval_store.clear()
+
+
 def test_command_response_includes_command_id(client_and_agent):
     # Hotkey (non-blocking) returns a server-generated command_id immediately.
     client, mock_router, _ = client_and_agent

--- a/jarvis-core/tests/test_tools_shell.py
+++ b/jarvis-core/tests/test_tools_shell.py
@@ -1,5 +1,7 @@
 import pytest
+import subprocess
 from pathlib import Path
+from unittest.mock import patch, MagicMock
 from tools.shell import ShellTool
 
 
@@ -66,3 +68,62 @@ def test_run_npm_style_command_in_project(tmp_path):
     result = ShellTool().run("npm run greet", cwd=str(tmp_path))
     assert result["exit_code"] == 0
     assert "hello project" in result["stdout"]
+
+
+# ── find_files: mdfind ────────────────────────────────────────────────────────
+
+def test_find_files_uses_mdfind_when_available(tmp_path):
+    """find_files delegates to mdfind on macOS when mdfind is on PATH."""
+    mock_result = MagicMock()
+    mock_result.stdout = str(tmp_path / "hello.py") + "\n"
+    mock_result.returncode = 0
+    with patch("shutil.which", return_value="/usr/bin/mdfind"), \
+         patch("tools.shell.subprocess.run", return_value=mock_result) as mock_run:
+        result = ShellTool().find_files("*.py", directory=str(tmp_path))
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "/usr/bin/mdfind"
+    assert result["error"] is None
+    assert result["count"] >= 1
+
+
+def test_find_files_falls_back_to_rglob_when_mdfind_unavailable(tmp_path):
+    """find_files falls back to rglob when mdfind is not on PATH."""
+    (tmp_path / "test.py").write_text("")
+    with patch("shutil.which", return_value=None):
+        result = ShellTool().find_files("*.py", directory=str(tmp_path))
+    assert result["error"] is None
+    assert any("test.py" in m for m in result["matches"])
+
+
+# ── search_content: ripgrep ───────────────────────────────────────────────────
+
+def test_search_content_uses_ripgrep_when_available(tmp_path):
+    """search_content uses rg when ripgrep is on PATH."""
+    mock_result = MagicMock()
+    mock_result.stdout = str(tmp_path / "foo.py") + "\n"
+    mock_result.returncode = 0
+    with patch("shutil.which", return_value="/usr/local/bin/rg"), \
+         patch("tools.shell.subprocess.run", return_value=mock_result) as mock_run:
+        ShellTool().search_content("pattern", directory=str(tmp_path))
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "/usr/local/bin/rg"
+
+
+def test_search_content_falls_back_to_grep_when_rg_unavailable(tmp_path):
+    """search_content falls back to grep when rg is not on PATH."""
+    (tmp_path / "file.py").write_text("hello world\n")
+    with patch("shutil.which", return_value=None):
+        result = ShellTool().search_content("hello", directory=str(tmp_path))
+    assert result["error"] is None
+
+
+def test_search_content_timeout_is_at_least_30s(tmp_path):
+    """search_content uses a timeout of at least 30 seconds."""
+    mock_result = MagicMock()
+    mock_result.stdout = ""
+    mock_result.returncode = 0
+    with patch("shutil.which", return_value=None), \
+         patch("tools.shell.subprocess.run", return_value=mock_result) as mock_run:
+        ShellTool().search_content("x", directory=str(tmp_path))
+    timeout = mock_run.call_args.kwargs.get("timeout") or mock_run.call_args[1].get("timeout", 0)
+    assert timeout >= 30

--- a/jarvis-core/tests/test_tools_web.py
+++ b/jarvis-core/tests/test_tools_web.py
@@ -1,4 +1,5 @@
 import pytest
+import httpx
 from unittest.mock import patch, MagicMock
 from tools.web import WebTool
 
@@ -13,7 +14,7 @@ def test_search_returns_results_with_content():
     </body></html>
     """
     mock_response.raise_for_status = MagicMock()
-    with patch("tools.web.requests.get", return_value=mock_response):
+    with patch("tools.web.httpx.get", return_value=mock_response):
         results = tool.search("python fastapi tutorial")
     assert isinstance(results, list)
     assert len(results) > 0
@@ -24,7 +25,7 @@ def test_search_returns_results_with_content():
 
 def test_search_handles_network_error():
     tool = WebTool(brave_api_key=None)
-    with patch("tools.web.requests.get", side_effect=Exception("network error")):
+    with patch("tools.web.httpx.get", side_effect=Exception("network error")):
         results = tool.search("anything")
     assert isinstance(results, list)
     assert len(results) == 1
@@ -36,7 +37,7 @@ def test_fetch_page_extracts_text():
     mock_response = MagicMock()
     mock_response.text = "<html><body><p>Hello world</p><p>More content here</p></body></html>"
     mock_response.raise_for_status = MagicMock()
-    with patch("tools.web.requests.get", return_value=mock_response):
+    with patch("tools.web.httpx.get", return_value=mock_response):
         result = tool.fetch_page("https://example.com")
     assert "Hello world" in result["text"]
     assert result["error"] is None
@@ -44,7 +45,43 @@ def test_fetch_page_extracts_text():
 
 def test_fetch_page_handles_error():
     tool = WebTool(brave_api_key=None)
-    with patch("tools.web.requests.get", side_effect=Exception("connection refused")):
+    with patch("tools.web.httpx.get", side_effect=Exception("connection refused")):
         result = tool.fetch_page("https://notreal.invalid")
     assert result["error"] is not None
     assert result["text"] is None
+
+
+def test_fetch_page_default_max_chars_is_20000():
+    """fetch_page default limit should be 20 000 chars, not 4 000."""
+    tool = WebTool(brave_api_key=None)
+    import inspect
+    sig = inspect.signature(tool.fetch_page)
+    assert sig.parameters["max_chars"].default == 20000
+
+
+def test_web_tool_uses_httpx_not_requests():
+    """WebTool should use httpx.get, not requests.get, for HTTP calls."""
+    tool = WebTool(brave_api_key=None)
+    mock_response = MagicMock()
+    mock_response.text = """
+    <html><body>
+    <div class="result__title"><a href="https://example.com">Title</a></div>
+    <div class="result__snippet">Snippet text</div>
+    </body></html>
+    """
+    mock_response.raise_for_status = MagicMock()
+    with patch("tools.web.httpx.get", return_value=mock_response) as mock_get:
+        results = tool.search("test query")
+    mock_get.assert_called_once()
+
+
+def test_fetch_page_uses_httpx():
+    """fetch_page should use httpx.get."""
+    tool = WebTool(brave_api_key=None)
+    mock_response = MagicMock()
+    mock_response.text = "<html><body><p>Hello</p></body></html>"
+    mock_response.raise_for_status = MagicMock()
+    with patch("tools.web.httpx.get", return_value=mock_response) as mock_get:
+        result = tool.fetch_page("https://example.com")
+    mock_get.assert_called_once()
+    assert result["error"] is None

--- a/jarvis-core/tests/test_train_classifier.py
+++ b/jarvis-core/tests/test_train_classifier.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import pytest
+
+from finetune_data.train_classifier import build_command, validate_inputs
+
+
+def test_build_command_uses_production_training_defaults():
+    command = build_command(
+        "/opt/homebrew/bin/mlx_lm.lora",
+        "mlx-community/Qwen3-4B-Instruct-2507-4bit",
+        Path("/data"),
+        Path("/adapters"),
+        smoke=False,
+    )
+    assert command[0] == "/opt/homebrew/bin/mlx_lm.lora"
+    assert command[command.index("--iters") + 1] == "600"
+    assert command[command.index("--batch-size") + 1] == "4"
+    assert command[command.index("--num-layers") + 1] == "8"
+    assert "--mask-prompt" in command
+
+
+def test_build_command_smoke_reduces_work():
+    command = build_command("mlx_lm.lora", "model", Path("/data"), Path("/adapters"), smoke=True)
+    assert command[command.index("--iters") + 1] == "1"
+    assert command[command.index("--batch-size") + 1] == "1"
+    assert command[command.index("--num-layers") + 1] == "1"
+
+
+def test_validate_inputs_requires_train_and_valid(tmp_path):
+    (tmp_path / "train.jsonl").write_text("{}\n")
+    with pytest.raises(FileNotFoundError, match="valid.jsonl"):
+        validate_inputs(tmp_path)
+
+    (tmp_path / "valid.jsonl").write_text("{}\n")
+    validate_inputs(tmp_path)

--- a/jarvis-core/tools/_dispatch.py
+++ b/jarvis-core/tools/_dispatch.py
@@ -48,6 +48,7 @@ def _code_guardrail_category(code: str) -> str:
 
 # Timeout for delegated Claude Code tasks (complex codebase work can take a while)
 _CLAUDE_CODE_TIMEOUT = 300
+_MAX_SHELL_TIMEOUT = 600
 
 TOOL_TO_GUARDRAIL_CATEGORY = {
     "shell_run": "run_shell",
@@ -105,7 +106,9 @@ def execute_tool(
     cwd = tool_input.get("cwd", default_cwd)
 
     if tool_name == "shell_run":
-        r = shell.run(tool_input["command"], cwd=cwd)
+        raw_timeout = tool_input.get("timeout")
+        timeout = min(int(raw_timeout), _MAX_SHELL_TIMEOUT) if raw_timeout is not None else 30
+        r = shell.run(tool_input["command"], cwd=cwd, timeout=timeout)
         return f"exit_code={r['exit_code']}\nstdout={r['stdout']}\nstderr={r['stderr']}"
     elif tool_name == "file_write":
         r = shell.write_file(tool_input["path"], tool_input["content"])
@@ -259,9 +262,13 @@ def format_response(text: str, tool_calls_made: list) -> dict:
     is_long = len(display) >= 150
     if has_code or is_long:
         plain = display.split("```")[0].strip()
-        first = plain.split(".")[0].strip()
+        # Find the first sentence boundary: sentence-ending punctuation followed by a
+        # space and an uppercase letter, but only when the period is NOT preceded by a
+        # digit (avoids splitting version numbers like "3.5" or "Python 3.11.2").
+        m = re.search(r'(?<!\d)([.!?])\s+(?=[A-Z])', plain)
+        first = plain[:m.end(1)].strip() if m else plain
         if 10 < len(first) <= 140:
-            speak = first + "."
+            speak = first
         elif 0 < len(plain) <= 140:
             speak = plain
         else:

--- a/jarvis-core/tools/shell.py
+++ b/jarvis-core/tools/shell.py
@@ -1,4 +1,5 @@
 import fnmatch
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -45,47 +46,95 @@ class ShellTool:
         """Case-insensitive file/directory search by name pattern under directory."""
         try:
             root = Path(directory).expanduser().resolve()
-            pattern_lower = pattern.lower()
-            matches = []
-            for p in root.rglob("*"):
-                if file_type == "file" and not p.is_file():
-                    continue
-                if file_type == "dir" and not p.is_dir():
-                    continue
-                if fnmatch.fnmatch(p.name.lower(), pattern_lower):
-                    matches.append(str(p))
-                if len(matches) >= 100:
-                    break
-            return {"matches": matches, "count": len(matches), "error": None}
+            mdfind_bin = shutil.which("mdfind")
+            if mdfind_bin:
+                return self._find_files_mdfind(mdfind_bin, pattern, root, file_type)
+            return self._find_files_rglob(pattern, root, file_type)
         except Exception as e:
             return {"matches": [], "count": 0, "error": str(e)}
+
+    def _find_files_mdfind(self, mdfind_bin: str, pattern: str, root: Path, file_type: str) -> dict:
+        query = f'kMDItemFSName == "{pattern}"c'
+        result = subprocess.run(
+            [mdfind_bin, query, "-onlyin", str(root)],
+            capture_output=True, text=True, timeout=15,
+        )
+        raw = [p for p in result.stdout.strip().splitlines() if p]
+        matches = []
+        for p_str in raw:
+            p = Path(p_str)
+            if file_type == "file" and not p.is_file():
+                continue
+            if file_type == "dir" and not p.is_dir():
+                continue
+            matches.append(p_str)
+            if len(matches) >= 100:
+                break
+        return {"matches": matches, "count": len(matches), "error": None}
+
+    def _find_files_rglob(self, pattern: str, root: Path, file_type: str) -> dict:
+        pattern_lower = pattern.lower()
+        matches = []
+        for p in root.rglob("*"):
+            if file_type == "file" and not p.is_file():
+                continue
+            if file_type == "dir" and not p.is_dir():
+                continue
+            if fnmatch.fnmatch(p.name.lower(), pattern_lower):
+                matches.append(str(p))
+            if len(matches) >= 100:
+                break
+        return {"matches": matches, "count": len(matches), "error": None}
 
     def search_content(self, pattern: str, directory: str = "~",
                        file_glob: str = "*", case_sensitive: bool = False) -> dict:
         """Search for a text pattern inside files. Returns matching file paths and lines."""
         try:
             root = Path(directory).expanduser().resolve()
-            flags = [] if case_sensitive else ["-i"]
-            # Add --exclude-dir for common large/irrelevant trees to avoid timeouts
-            excludes = ["--exclude-dir=.git", "--exclude-dir=.venv", "--exclude-dir=node_modules",
-                        "--exclude-dir=__pycache__", "--exclude-dir=.DS_Store"]
-            result = subprocess.run(
-                ["grep", "-r", "--include", file_glob, "-l", *flags, *excludes, pattern, str(root)],
-                capture_output=True, text=True, timeout=10
-            )
-            files = [f for f in result.stdout.strip().splitlines() if f]
-            # For each matched file get the matching lines (up to 5 per file)
-            snippets = []
-            for fpath in files[:20]:
-                r2 = subprocess.run(
-                    ["grep", "-n", "--include", file_glob, *flags, "-m", "5", pattern, fpath],
-                    capture_output=True, text=True, timeout=5
-                )
-                if r2.stdout.strip():
-                    snippets.append({"file": fpath, "lines": r2.stdout.strip().splitlines()})
-            return {"files": files, "snippets": snippets, "count": len(files), "error": None}
+            rg_bin = shutil.which("rg")
+            if rg_bin:
+                return self._search_content_rg(rg_bin, pattern, root, file_glob, case_sensitive)
+            return self._search_content_grep(pattern, root, file_glob, case_sensitive)
         except Exception as e:
             return {"files": [], "snippets": [], "count": 0, "error": str(e)}
+
+    def _search_content_rg(self, rg_bin: str, pattern: str, root: Path,
+                            file_glob: str, case_sensitive: bool) -> dict:
+        flags = [] if case_sensitive else ["-i"]
+        result = subprocess.run(
+            [rg_bin, "-l", "--glob", file_glob, *flags, pattern, str(root)],
+            capture_output=True, text=True, timeout=30,
+        )
+        files = [f for f in result.stdout.strip().splitlines() if f]
+        snippets = []
+        for fpath in files[:20]:
+            r2 = subprocess.run(
+                [rg_bin, "-n", "-m", "5", "--glob", file_glob, *flags, pattern, fpath],
+                capture_output=True, text=True, timeout=10,
+            )
+            if r2.stdout.strip():
+                snippets.append({"file": fpath, "lines": r2.stdout.strip().splitlines()})
+        return {"files": files, "snippets": snippets, "count": len(files), "error": None}
+
+    def _search_content_grep(self, pattern: str, root: Path,
+                              file_glob: str, case_sensitive: bool) -> dict:
+        flags = [] if case_sensitive else ["-i"]
+        excludes = ["--exclude-dir=.git", "--exclude-dir=.venv", "--exclude-dir=node_modules",
+                    "--exclude-dir=__pycache__", "--exclude-dir=.DS_Store"]
+        result = subprocess.run(
+            ["grep", "-r", "--include", file_glob, "-l", *flags, *excludes, pattern, str(root)],
+            capture_output=True, text=True, timeout=30,
+        )
+        files = [f for f in result.stdout.strip().splitlines() if f]
+        snippets = []
+        for fpath in files[:20]:
+            r2 = subprocess.run(
+                ["grep", "-n", "--include", file_glob, *flags, "-m", "5", pattern, fpath],
+                capture_output=True, text=True, timeout=10,
+            )
+            if r2.stdout.strip():
+                snippets.append({"file": fpath, "lines": r2.stdout.strip().splitlines()})
+        return {"files": files, "snippets": snippets, "count": len(files), "error": None}
 
     def file_edit(self, path: str, old_string: str, new_string: str,
                   replace_all: bool = False) -> dict:

--- a/jarvis-core/tools/web.py
+++ b/jarvis-core/tools/web.py
@@ -1,4 +1,4 @@
-import requests
+import httpx
 from bs4 import BeautifulSoup
 from urllib.parse import quote_plus
 
@@ -18,7 +18,7 @@ class WebTool:
     def _brave_search(self, query: str, num_results: int) -> list[dict]:
         url = "https://api.search.brave.com/res/v1/web/search"
         headers = {"Accept": "application/json", "X-Subscription-Token": self._brave_key}
-        resp = requests.get(url, params={"q": query, "count": num_results}, headers=headers, timeout=10)
+        resp = httpx.get(url, params={"q": query, "count": num_results}, headers=headers, timeout=10)
         resp.raise_for_status()
         data = resp.json()
         results = data.get("web", {}).get("results", [])
@@ -27,7 +27,7 @@ class WebTool:
     def _ddg_search(self, query: str, num_results: int) -> list[dict]:
         url = f"https://html.duckduckgo.com/html/?q={quote_plus(query)}"
         headers = {"User-Agent": "Mozilla/5.0"}
-        resp = requests.get(url, headers=headers, timeout=10)
+        resp = httpx.get(url, headers=headers, timeout=10)
         resp.raise_for_status()
         soup = BeautifulSoup(resp.text, "html.parser")
         results = []
@@ -41,10 +41,10 @@ class WebTool:
             })
         return results
 
-    def fetch_page(self, url: str, max_chars: int = 4000) -> dict:
+    def fetch_page(self, url: str, max_chars: int = 20000) -> dict:
         try:
             headers = {"User-Agent": "Mozilla/5.0"}
-            resp = requests.get(url, headers=headers, timeout=15)
+            resp = httpx.get(url, headers=headers, timeout=15)
             resp.raise_for_status()
             soup = BeautifulSoup(resp.text, "html.parser")
             for tag in soup(["script", "style", "nav", "footer", "header"]):


### PR DESCRIPTION
## Summary

- **Executor → Rapid-MLX**: Qwen3.6-35B-A3B on Rapid-MLX (`p50 1744ms`) vs Ollama (`p50 5969ms`) — 3.4x faster, 100% tool accuracy unchanged. Auto-starts at boot via `_ensure_executor_server_running`.
- **Classifier LoRA promoted**: Qwen3-4B LoRA (90.1% accuracy, +11.9pp vs vanilla) with zero latency overhead (`p50 0.936s` = vanilla). Adapter-aware startup wired in `_ensure_classifier_server_running`.
- **All 9 §2.6 bugs fixed**: `threading.Lock` busy-flag, `mdfind`/`rg` fast search, `httpx` consolidation, 20k fetch truncation, shell `timeout` passthrough (capped 600s), shared `httpx.Client` in router, `[Tools used: …]` annotation removed from history, decimal-safe sentence split, `timeout` in `shell_run` schema.
- **Full fine-tuning pipeline**: curation (`curate.py`, `curate_classifier.py`), training (`train_classifier.py`), evaluation (`evaluate_classifier.py`) — 1007 classifier examples, 600 training iterations.

## Test plan

- [ ] 381 tests passing (`pytest`)
- [ ] Swift app builds (⌘B)
- [ ] Live: restart Jarvis server, confirm rapid-mlx executor auto-starts on :8093
- [ ] Live: confirm classifier MLX server auto-starts on :8090 with LoRA adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)