### PR TITLE
feat: Phase E — conversational session with compaction

### DIFF
--- a/jarvis-core/agent.py
+++ b/jarvis-core/agent.py
@@ -456,6 +456,7 @@ class _ClaudeLoopState:
     pending_content: list | None = None
     pending_index: int = 0
     pending_results: list | None = None
+    wrap_up_nudged: bool = False
 
 
 class Agent:
@@ -541,16 +542,14 @@ class Agent:
         wrap_up_step = max_steps - 2
 
         for _ in range(max_steps):
-            if state.total_steps >= wrap_up_step:
+            if state.total_steps >= wrap_up_step and not state.wrap_up_nudged:
+                state.wrap_up_nudged = True
                 nudge = (
                     "You are approaching your step limit. Based on everything you have found so far, "
                     "call finalize() now with your best answer — include what you discovered and what "
                     "still needs to be done if the task isn't complete."
                 )
-                last_content = state.messages[-1].get("content") if state.messages else None
-                already_nudged = isinstance(last_content, str) and "approaching your step limit" in last_content
-                if not already_nudged:
-                    state.messages.append({"role": "user", "content": nudge})
+                state.messages.append({"role": "user", "content": nudge})
 
             # Omit delegate_to_local when Ollama is down to avoid wasting a step.
             # Omit notify for scheduled tasks — the scheduler fires the notification itself.

--- a/jarvis-core/agent.py
+++ b/jarvis-core/agent.py
@@ -536,12 +536,21 @@ class Agent:
         return self._outer_loop(state, step_callback)
 
     def _outer_loop(self, state: "_ClaudeLoopState", step_callback) -> dict:
-        max_steps = self._config.get("reasoning", {}).get("max_steps_claude", 5)
-        max_total = self._config.get("reasoning", {}).get("max_total_steps", 20)
+        max_steps = self._config.get("reasoning", {}).get("max_steps_claude", 15)
+
+        wrap_up_step = max_steps - 2
 
         for _ in range(max_steps):
-            if state.total_steps >= max_total:
-                return {**format_response("I reached the maximum step limit.", state.tool_calls_made), "steps": state.steps}
+            if state.total_steps >= wrap_up_step:
+                nudge = (
+                    "You are approaching your step limit. Based on everything you have found so far, "
+                    "call finalize() now with your best answer — include what you discovered and what "
+                    "still needs to be done if the task isn't complete."
+                )
+                last_content = state.messages[-1].get("content") if state.messages else None
+                already_nudged = isinstance(last_content, str) and "approaching your step limit" in last_content
+                if not already_nudged:
+                    state.messages.append({"role": "user", "content": nudge})
 
             # Omit delegate_to_local when Ollama is down to avoid wasting a step.
             # Omit notify for scheduled tasks — the scheduler fires the notification itself.
@@ -639,7 +648,7 @@ class Agent:
                         coding=self._coding,
                         mcp_manager=self._mcp_manager,
                     )
-                step["result_summary"] = result[:120] if isinstance(result, str) else str(result)[:120]
+                step["result_summary"] = result[:200] if isinstance(result, str) else str(result)[:200]
                 state.tool_calls_made.append(block.name)
                 tool_results.append({
                     "type": "tool_result",

--- a/jarvis-core/config.py
+++ b/jarvis-core/config.py
@@ -40,16 +40,9 @@ DEFAULTS = {
         "classifier_adapter_path": "",
     },
     "reasoning": {
-        "max_steps_claude": 10,
-        "max_steps_ollama": 10,
-        "max_total_steps": 20,
+        "max_steps_claude": 15,
+        "max_steps_ollama": 15,
         "stall_detection": True,
-        "step_budgets": {
-            "read_only": 5,
-            "prepare": 8,
-            "destructive": 10,
-            "complex_reasoning": 10,
-        },
     },
     "narration": {
         "mode": "milestones",   # milestones | all | silent

--- a/jarvis-core/ollama_agent.py
+++ b/jarvis-core/ollama_agent.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import time as _time
 from dataclasses import dataclass, field
 import httpx
 import approval_store
@@ -14,7 +15,8 @@ from agent import TOOL_DEFINITIONS, _BASE_SYSTEM_PROMPT, _step_label
 from tools._errors import ApprovalRequiredError
 
 _PLANNING_RE = re.compile(
-    r"^(let me\b|i('ll| will)\b|i'm going to\b|i need to\b|i'll start\b|"
+    r"^(now\s+|ok(ay)?,?\s+|sure,?\s+|well,?\s+|alright,?\s+|great,?\s+)?"
+    r"(let me\b|i('ll| will)\b|i'm going to\b|i need to\b|i'll start\b|"
     r"i'll check\b|i'll look\b|i'll fetch\b|i'll get\b|i'll find\b|i'll run\b|i'll read\b|"
     r"to do this\b|here's what i|first[,\s]i)",
     re.IGNORECASE,
@@ -23,9 +25,10 @@ _PLANNING_RE = re.compile(
 
 def _is_planning_text(text: str) -> bool:
     """Return True if this looks like planning/intent text without actual content.
-    Used to decide whether to nudge the model back toward tool use."""
+    Used to decide whether to nudge the model back toward tool use.
+    Empty text is also treated as non-final — the model gave up silently."""
     if not text:
-        return False
+        return True
     first_line = text.strip().split("\n")[0].strip()
     return bool(_PLANNING_RE.match(first_line))
 
@@ -111,14 +114,19 @@ _FINALIZE_TOOL = {
 _OLLAMA_TOOLS = _anthropic_to_ollama_tools(_OLLAMA_SAFE_TOOL_DEFINITIONS) + [_FINALIZE_TOOL]
 
 
+_FINALIZE_ANSWER_RE = re.compile(r'"answer"\s*:\s*"')
+
+
 def _stream_call(client: "httpx.Client", url: str, payload: dict,
-                 step_callback) -> tuple[dict, str | None]:
+                 step_callback, composing_state: list | None = None,
+                 metrics_out: dict | None = None) -> tuple[dict, str | None]:
     """Make a streaming LLM call. Returns (msg, finish_reason) in same shape as non-streaming.
 
     Branches on first meaningful chunk:
-    - tool_calls: accumulate fragments silently, no visual output
-    - content: fire step_callback({"type": "token", "text": token}) for each token
+    - tool_calls: accumulate fragments silently; finalize(answer=...) streams answer tokens
+    - content: fire step_callback({"type": "token", "text": token}) per word boundary
 
+    If metrics_out is provided it is populated with: ttft_ms, tokens, gen_ms, tok_s.
     Falls back to non-streaming POST on any exception.
     """
     try:
@@ -128,6 +136,16 @@ def _stream_call(client: "httpx.Client", url: str, payload: dict,
             accumulated: dict[int, dict] = {}  # index → {id, name, arguments}
             finish_reason: str | None = None
             is_text: bool | None = None  # None until first meaningful chunk
+            # composing_state is a 1-element list so callers can share the flag across calls
+            # Per-index state for streaming finalize answer content as tokens.
+            # "started": True once we've found the answer value opening quote.
+            # "tail": last 2 chars buffered to avoid emitting the closing `"}`.
+            _fin: dict[int, dict] = {}
+            # Latency / throughput metrics
+            _t_start: float = _time.monotonic()
+            _t_first_token: float | None = None
+            _token_count: int = 0
+            _t_last_token: float = _t_start
 
             for line in resp.iter_lines():
                 if not line or not line.startswith("data: "):
@@ -156,7 +174,15 @@ def _stream_call(client: "httpx.Client", url: str, payload: dict,
                     token = delta.get("content", "")
                     if token:
                         full_content += token
+                        _now = _time.monotonic()
+                        if _t_first_token is None:
+                            _t_first_token = _now
+                        _token_count += 1
+                        _t_last_token = _now
                         if step_callback:
+                            if composing_state is not None and not composing_state[0]:
+                                composing_state[0] = True
+                                step_callback({"type": "step", "label": "Composing response…", "tool": "text", "milestone": False})
                             step_callback({"type": "token", "text": token})
                 elif is_text is False:
                     for tc_delta in delta.get("tool_calls", []):
@@ -169,7 +195,45 @@ def _stream_call(client: "httpx.Client", url: str, payload: dict,
                         if func.get("name"):
                             accumulated[idx]["name"] = func["name"]
                         if func.get("arguments"):
-                            accumulated[idx]["arguments"] += func["arguments"]
+                            arg_chunk = func["arguments"]
+                            accumulated[idx]["arguments"] += arg_chunk
+
+                            # Stream finalize answer tokens so the HUD doesn't
+                            # sit blank for the entire answer-generation time.
+                            if step_callback and accumulated[idx].get("name") == "finalize":
+                                if idx not in _fin:
+                                    _fin[idx] = {"started": False, "pending": "", "tail": ""}
+                                fb = _fin[idx]
+                                if not fb["started"]:
+                                    fb["pending"] += arg_chunk
+                                    m = _FINALIZE_ANSWER_RE.search(fb["pending"])
+                                    if m:
+                                        fb["started"] = True
+                                        if composing_state is not None and not composing_state[0]:
+                                            composing_state[0] = True
+                                            step_callback({"type": "step", "label": "Composing response…", "tool": "finalize", "milestone": False})
+                                        content = fb["pending"][m.end():]
+                                        # Buffer last 2 chars to avoid emitting closing `"}`.
+                                        if len(content) > 2:
+                                            step_callback({"type": "token", "text": content[:-2]})
+                                            fb["tail"] = content[-2:]
+                                        else:
+                                            fb["tail"] = content
+                                else:
+                                    combined = fb["tail"] + arg_chunk
+                                    if len(combined) > 2:
+                                        step_callback({"type": "token", "text": combined[:-2]})
+                                        fb["tail"] = combined[-2:]
+                                    else:
+                                        fb["tail"] = combined
+
+        # Populate metrics
+        if metrics_out is not None and _token_count > 0:
+            gen_ms = int((_t_last_token - (_t_first_token or _t_start)) * 1000) or 1
+            metrics_out["ttft_ms"] = int((_t_first_token - _t_start) * 1000) if _t_first_token else None
+            metrics_out["tokens"] = _token_count
+            metrics_out["gen_ms"] = gen_ms
+            metrics_out["tok_s"] = round(_token_count / (gen_ms / 1000), 1)
 
         # Reconstruct msg in non-streaming shape
         if accumulated:
@@ -218,6 +282,8 @@ class _OllamaLoopState:
     pending_tool_calls: list | None = None
     pending_index: int = 0
     no_tool_retries: int = 0
+    composing_emitted: bool = False
+    gen_metrics: dict = field(default_factory=dict)
 
 
 class OllamaAgent:
@@ -349,7 +415,12 @@ class OllamaAgent:
                 if self._chat_template_kwargs:
                     payload["chat_template_kwargs"] = self._chat_template_kwargs
 
-                msg, finish = _stream_call(self._http_client, url, payload, step_callback)
+                composing_state = [state.composing_emitted]
+                call_metrics: dict = {}
+                msg, finish = _stream_call(self._http_client, url, payload, step_callback, composing_state, call_metrics)
+                state.composing_emitted = composing_state[0]
+                if call_metrics:
+                    state.gen_metrics = call_metrics  # keep last text-generating call's metrics
 
                 if finish == "stop" or not msg.get("tool_calls"):
                     text = _clean_ollama_text(msg.get("content") or "")
@@ -360,6 +431,7 @@ class OllamaAgent:
                     if not _is_planning_text(text):
                         result = format_response(text, state.tool_calls_made)
                         result["steps"] = state.steps
+                        result.update(state.gen_metrics)
                         return result
 
                     # Planning text returned — model wants to continue but didn't call a tool.
@@ -368,7 +440,12 @@ class OllamaAgent:
                         state.no_tool_retries += 1
                         state.steps_used -= 1  # don't burn a step on the nudge
                         state.messages.append({"role": "assistant", "content": text})
-                        if state.tool_calls_made:
+                        if not text:
+                            nudge = (
+                                "You returned an empty response. Based on the tool results so far, "
+                                "either call the next tool to continue, or call finalize() with your answer."
+                            )
+                        elif state.tool_calls_made:
                             nudge = (
                                 "You've made progress but returned planning text instead of calling a tool. "
                                 "Continue by calling the next tool now — do not write a text response."
@@ -387,6 +464,7 @@ class OllamaAgent:
                     if state.tool_calls_made:
                         result = format_response(text, state.tool_calls_made)
                         result["steps"] = state.steps
+                        result.update(state.gen_metrics)
                         return result
                     raise EscalateToCloud("Model returned text without tool calls after 2 retries")
 

--- a/jarvis-core/ollama_agent.py
+++ b/jarvis-core/ollama_agent.py
@@ -356,28 +356,38 @@ class OllamaAgent:
                     if not text and not state.tool_calls_made and finish != "stop":
                         raise EscalateToCloud("Empty response from local executor — server may have crashed")
 
-                    # If this is a genuine final answer (tool calls were made, or it's a
-                    # simple conversational reply that isn't just planning text), return now.
-                    if state.tool_calls_made or not _is_planning_text(text):
+                    # Genuine final answer: text is not planning-intent. Return now.
+                    if not _is_planning_text(text):
                         result = format_response(text, state.tool_calls_made)
                         result["steps"] = state.steps
                         return result
 
-                    # Model returned planning text with no tool calls — nudge it.
+                    # Planning text returned — model wants to continue but didn't call a tool.
+                    # Nudge regardless of whether previous tool calls were made.
                     if state.no_tool_retries < 2:
                         state.no_tool_retries += 1
                         state.steps_used -= 1  # don't burn a step on the nudge
                         state.messages.append({"role": "assistant", "content": text})
-                        nudge = (
-                            "You returned text but made no tool calls. "
-                            "You MUST call the appropriate tool now — do not write a text response."
-                        )
+                        if state.tool_calls_made:
+                            nudge = (
+                                "You've made progress but returned planning text instead of calling a tool. "
+                                "Continue by calling the next tool now — do not write a text response."
+                            )
+                        else:
+                            nudge = (
+                                "You returned text but made no tool calls. "
+                                "You MUST call the appropriate tool now — do not write a text response."
+                            )
                         if step_callback:
                             step_callback({"type": "clear"})
                         state.messages.append({"role": "user", "content": nudge})
                         continue
 
-                    # 2 retries exhausted and still no tool calls — escalate to Claude.
+                    # 2 retries exhausted — if we did useful work, return it; otherwise escalate.
+                    if state.tool_calls_made:
+                        result = format_response(text, state.tool_calls_made)
+                        result["steps"] = state.steps
+                        return result
                     raise EscalateToCloud("Model returned text without tool calls after 2 retries")
 
                 state.messages.append(msg)

--- a/jarvis-core/ollama_agent.py
+++ b/jarvis-core/ollama_agent.py
@@ -278,11 +278,7 @@ class OllamaAgent:
         if memory_context:
             system_msg += f"\nProject memory: {memory_context}\n"
 
-        budgets = self._config.get("reasoning", {}).get("step_budgets", {})
-        if intent_class and intent_class in budgets:
-            max_steps = int(budgets[intent_class])
-        else:
-            max_steps = int(self._config.get("reasoning", {}).get("max_steps_ollama", 10))
+        max_steps = int(self._config.get("reasoning", {}).get("max_steps_ollama", 15))
 
         state = _OllamaLoopState(
             messages=[
@@ -316,8 +312,20 @@ class OllamaAgent:
 
     def _outer_loop(self, state: "_OllamaLoopState", step_callback) -> dict:
         url = f"{self._host}/v1/chat/completions"
+        wrap_up_step = state.max_steps - 2
         try:
             while state.steps_used < state.max_steps:
+                if state.steps_used >= wrap_up_step:
+                    nudge = (
+                        "You are approaching your step limit. Based on everything you have found so far, "
+                        "call finalize() now with your best answer — include what you discovered and what "
+                        "still needs to be done if the task isn't complete."
+                    )
+                    last_content = state.messages[-1].get("content") if state.messages else None
+                    already_nudged = isinstance(last_content, str) and "approaching your step limit" in last_content
+                    if not already_nudged:
+                        state.messages.append({"role": "user", "content": nudge})
+
                 state.steps_used += 1
                 payload = {"model": self._model, "messages": state.messages, "tools": self._build_tool_list()}
                 if self._chat_template_kwargs:
@@ -447,7 +455,7 @@ class OllamaAgent:
                 step_callback({"type": "step", "label": _step_label(name), "tool": name, "milestone": step["milestone"]})
             try:
                 result = execute_tool(name, args, self._shell, self._web, self._code, self._macos, self._guardrails, default_cwd=state.cwd, coding=self._coding, mcp_manager=self._mcp_manager)
-                step["result_summary"] = result[:120] if isinstance(result, str) else str(result)[:120]
+                step["result_summary"] = result[:200] if isinstance(result, str) else str(result)[:200]
                 state.tool_calls_made.append(name)
             except ApprovalRequiredError as e:
                 # Revert this call's loop-state effects so resume re-processes it cleanly.

--- a/jarvis-core/ollama_agent.py
+++ b/jarvis-core/ollama_agent.py
@@ -116,6 +116,30 @@ _OLLAMA_TOOLS = _anthropic_to_ollama_tools(_OLLAMA_SAFE_TOOL_DEFINITIONS) + [_FI
 
 _FINALIZE_ANSWER_RE = re.compile(r'"answer"\s*:\s*"')
 
+_JSON_ESCAPE_MAP = {'"': '"', '\\': '\\', '/': '/', 'b': '\b',
+                    'f': '\f', 'n': '\n', 'r': '\r', 't': '\t'}
+
+
+def _decode_json_string_chunk(chunk: str, state: dict) -> tuple[str, bool]:
+    """Incrementally decode a chunk of a JSON string value.
+
+    state must have 'in_escape' (bool). Mutated in-place.
+    Returns (decoded_output, is_done) where is_done=True when the closing
+    unescaped '"' is found. Handles \\uXXXX by passing through literally.
+    """
+    out: list[str] = []
+    for ch in chunk:
+        if state["in_escape"]:
+            out.append(_JSON_ESCAPE_MAP.get(ch, ch))
+            state["in_escape"] = False
+        elif ch == '\\':
+            state["in_escape"] = True
+        elif ch == '"':
+            return ''.join(out), True  # hit closing quote of the JSON string value
+        else:
+            out.append(ch)
+    return ''.join(out), False
+
 
 def _stream_call(client: "httpx.Client", url: str, payload: dict,
                  step_callback, composing_state: list | None = None,
@@ -123,10 +147,11 @@ def _stream_call(client: "httpx.Client", url: str, payload: dict,
     """Make a streaming LLM call. Returns (msg, finish_reason) in same shape as non-streaming.
 
     Branches on first meaningful chunk:
-    - tool_calls: accumulate fragments silently; finalize(answer=...) streams answer tokens
-    - content: fire step_callback({"type": "token", "text": token}) per word boundary
+    - tool_calls: accumulate fragments silently; finalize(answer=...) streams decoded answer tokens
+    - content: fire step_callback({"type": "token", "text": token}) per fragment
 
     If metrics_out is provided it is populated with: ttft_ms, tokens, gen_ms, tok_s.
+    Tokens are counted for both text and finalize-answer paths.
     Falls back to non-streaming POST on any exception.
     """
     try:
@@ -136,12 +161,10 @@ def _stream_call(client: "httpx.Client", url: str, payload: dict,
             accumulated: dict[int, dict] = {}  # index → {id, name, arguments}
             finish_reason: str | None = None
             is_text: bool | None = None  # None until first meaningful chunk
-            # composing_state is a 1-element list so callers can share the flag across calls
-            # Per-index state for streaming finalize answer content as tokens.
-            # "started": True once we've found the answer value opening quote.
-            # "tail": last 2 chars buffered to avoid emitting the closing `"}`.
+            # Per-index state for streaming finalize answer content as decoded tokens.
+            # Uses an escape-aware JSON string decoder — no tail buffer needed.
             _fin: dict[int, dict] = {}
-            # Latency / throughput metrics
+            # Latency / throughput metrics (tracked for both text and finalize paths)
             _t_start: float = _time.monotonic()
             _t_first_token: float | None = None
             _token_count: int = 0
@@ -198,12 +221,15 @@ def _stream_call(client: "httpx.Client", url: str, payload: dict,
                             arg_chunk = func["arguments"]
                             accumulated[idx]["arguments"] += arg_chunk
 
-                            # Stream finalize answer tokens so the HUD doesn't
-                            # sit blank for the entire answer-generation time.
+                            # Stream finalize answer as decoded tokens so the HUD
+                            # shows the answer building up during generation.
                             if step_callback and accumulated[idx].get("name") == "finalize":
                                 if idx not in _fin:
-                                    _fin[idx] = {"started": False, "pending": "", "tail": ""}
+                                    _fin[idx] = {"started": False, "pending": "",
+                                                 "in_escape": False, "done": False}
                                 fb = _fin[idx]
+                                if fb["done"]:
+                                    continue
                                 if not fb["started"]:
                                     fb["pending"] += arg_chunk
                                     m = _FINALIZE_ANSWER_RE.search(fb["pending"])
@@ -212,22 +238,27 @@ def _stream_call(client: "httpx.Client", url: str, payload: dict,
                                         if composing_state is not None and not composing_state[0]:
                                             composing_state[0] = True
                                             step_callback({"type": "step", "label": "Composing response…", "tool": "finalize", "milestone": False})
-                                        content = fb["pending"][m.end():]
-                                        # Buffer last 2 chars to avoid emitting closing `"}`.
-                                        if len(content) > 2:
-                                            step_callback({"type": "token", "text": content[:-2]})
-                                            fb["tail"] = content[-2:]
-                                        else:
-                                            fb["tail"] = content
+                                        decoded, done = _decode_json_string_chunk(fb["pending"][m.end():], fb)
+                                        if decoded:
+                                            step_callback({"type": "token", "text": decoded})
+                                            _now = _time.monotonic()
+                                            if _t_first_token is None:
+                                                _t_first_token = _now
+                                            _token_count += 1
+                                            _t_last_token = _now
+                                        fb["done"] = done
                                 else:
-                                    combined = fb["tail"] + arg_chunk
-                                    if len(combined) > 2:
-                                        step_callback({"type": "token", "text": combined[:-2]})
-                                        fb["tail"] = combined[-2:]
-                                    else:
-                                        fb["tail"] = combined
+                                    decoded, done = _decode_json_string_chunk(arg_chunk, fb)
+                                    if decoded:
+                                        step_callback({"type": "token", "text": decoded})
+                                        _now = _time.monotonic()
+                                        if _t_first_token is None:
+                                            _t_first_token = _now
+                                        _token_count += 1
+                                        _t_last_token = _now
+                                    fb["done"] = done
 
-        # Populate metrics
+        # Populate metrics (captured for both text and finalize paths)
         if metrics_out is not None and _token_count > 0:
             gen_ms = int((_t_last_token - (_t_first_token or _t_start)) * 1000) or 1
             metrics_out["ttft_ms"] = int((_t_first_token - _t_start) * 1000) if _t_first_token else None
@@ -284,6 +315,7 @@ class _OllamaLoopState:
     no_tool_retries: int = 0
     composing_emitted: bool = False
     gen_metrics: dict = field(default_factory=dict)
+    wrap_up_nudged: bool = False
 
 
 class OllamaAgent:
@@ -399,16 +431,14 @@ class OllamaAgent:
         wrap_up_step = state.max_steps - 2
         try:
             while state.steps_used < state.max_steps:
-                if state.steps_used >= wrap_up_step:
+                if state.steps_used >= wrap_up_step and not state.wrap_up_nudged:
+                    state.wrap_up_nudged = True
                     nudge = (
                         "You are approaching your step limit. Based on everything you have found so far, "
                         "call finalize() now with your best answer — include what you discovered and what "
                         "still needs to be done if the task isn't complete."
                     )
-                    last_content = state.messages[-1].get("content") if state.messages else None
-                    already_nudged = isinstance(last_content, str) and "approaching your step limit" in last_content
-                    if not already_nudged:
-                        state.messages.append({"role": "user", "content": nudge})
+                    state.messages.append({"role": "user", "content": nudge})
 
                 state.steps_used += 1
                 payload = {"model": self._model, "messages": state.messages, "tools": self._build_tool_list()}
@@ -439,7 +469,9 @@ class OllamaAgent:
                     if state.no_tool_retries < 2:
                         state.no_tool_retries += 1
                         state.steps_used -= 1  # don't burn a step on the nudge
-                        state.messages.append({"role": "assistant", "content": text})
+                        state.composing_emitted = False  # allow "Composing response…" to refire
+                        if text:  # never append an empty assistant message — some backends reject it
+                            state.messages.append({"role": "assistant", "content": text})
                         if not text:
                             nudge = (
                                 "You returned an empty response. Based on the tool results so far, "
@@ -584,6 +616,7 @@ class OllamaAgent:
                 result = execute_tool(name, args, self._shell, self._web, self._code, self._macos, self._guardrails, default_cwd=state.cwd, coding=self._coding, mcp_manager=self._mcp_manager)
                 step["result_summary"] = result[:200] if isinstance(result, str) else str(result)[:200]
                 state.tool_calls_made.append(name)
+                state.no_tool_retries = 0  # successful tool call resets retry budget
             except ApprovalRequiredError as e:
                 # Revert this call's loop-state effects so resume re-processes it cleanly.
                 state.steps.pop()

--- a/jarvis-core/ollama_agent.py
+++ b/jarvis-core/ollama_agent.py
@@ -13,6 +13,23 @@ from tools._dispatch import execute_tool, format_response
 from agent import TOOL_DEFINITIONS, _BASE_SYSTEM_PROMPT, _step_label
 from tools._errors import ApprovalRequiredError
 
+_PLANNING_RE = re.compile(
+    r"^(let me\b|i('ll| will)\b|i'm going to\b|i need to\b|i'll start\b|"
+    r"i'll check\b|i'll look\b|i'll fetch\b|i'll get\b|i'll find\b|i'll run\b|i'll read\b|"
+    r"to do this\b|here's what i|first[,\s]i)",
+    re.IGNORECASE,
+)
+
+
+def _is_planning_text(text: str) -> bool:
+    """Return True if this looks like planning/intent text without actual content.
+    Used to decide whether to nudge the model back toward tool use."""
+    if not text:
+        return False
+    first_line = text.strip().split("\n")[0].strip()
+    return bool(_PLANNING_RE.match(first_line))
+
+
 # Appended to the base system prompt for local models that need extra guidance
 _OLLAMA_EXTRA = """
 CRITICAL RULES FOR THIS MODEL:
@@ -200,6 +217,7 @@ class _OllamaLoopState:
     user_text: str
     pending_tool_calls: list | None = None
     pending_index: int = 0
+    no_tool_retries: int = 0
 
 
 class OllamaAgent:
@@ -337,9 +355,30 @@ class OllamaAgent:
                     text = _clean_ollama_text(msg.get("content") or "")
                     if not text and not state.tool_calls_made and finish != "stop":
                         raise EscalateToCloud("Empty response from local executor — server may have crashed")
-                    result = format_response(text, state.tool_calls_made)
-                    result["steps"] = state.steps
-                    return result
+
+                    # If this is a genuine final answer (tool calls were made, or it's a
+                    # simple conversational reply that isn't just planning text), return now.
+                    if state.tool_calls_made or not _is_planning_text(text):
+                        result = format_response(text, state.tool_calls_made)
+                        result["steps"] = state.steps
+                        return result
+
+                    # Model returned planning text with no tool calls — nudge it.
+                    if state.no_tool_retries < 2:
+                        state.no_tool_retries += 1
+                        state.steps_used -= 1  # don't burn a step on the nudge
+                        state.messages.append({"role": "assistant", "content": text})
+                        nudge = (
+                            "You returned text but made no tool calls. "
+                            "You MUST call the appropriate tool now — do not write a text response."
+                        )
+                        if step_callback:
+                            step_callback({"type": "clear"})
+                        state.messages.append({"role": "user", "content": nudge})
+                        continue
+
+                    # 2 retries exhausted and still no tool calls — escalate to Claude.
+                    raise EscalateToCloud("Model returned text without tool calls after 2 retries")
 
                 state.messages.append(msg)
                 kind, result = self._process_tools(state, msg["tool_calls"], 0, step_callback)

--- a/jarvis-core/router.py
+++ b/jarvis-core/router.py
@@ -1,3 +1,4 @@
+import anthropic as _anthropic
 import json
 import logging
 import time
@@ -15,8 +16,6 @@ class Router:
     Returns the same response dict shape as both agents, plus routing metadata.
     """
 
-    _MAX_HISTORY = 10  # 5 turns (user + assistant per turn)
-
     def __init__(self, config: dict, guardrails: Guardrails, mcp_manager=None):
         self._config = config
         self._http_client = httpx.Client(timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=5.0))
@@ -29,6 +28,8 @@ class Router:
                              local_agent=self._ollama, model=sonnet_model, mcp_manager=mcp_manager)
         self._claude = self._sonnet   # legacy alias for claude_only / ollama_first modes
         self._history: list[dict] = []
+        self._pending_compaction_notice: bool = False
+        self._anthropic_client = _anthropic.Anthropic(api_key=config.get("anthropic_api_key", ""))
 
     def reset_conversation(self) -> None:
         self._history = []
@@ -72,15 +73,17 @@ class Router:
     def _ollama_timeout(self) -> float:
         return float(self._config.get("ollama", {}).get("timeout_seconds", 30))
 
-    def _classify(self, text: str) -> dict:
+    def _classify(self, text: str, history: list | None = None) -> dict:
         """Ask the classifier to classify intent. Returns classification dict.
         Raises on any error — caller handles gracefully."""
+        history_context = (history or [])[-4:]  # last 2 turns = 4 messages
         resp = self._http_client.post(
             f"{self._classifier_host}/v1/chat/completions",
             json={
                 "model": self._classifier_model,
                 "messages": [
                     {"role": "system", "content": CLASSIFY_SYSTEM_PROMPT},
+                    *history_context,
                     {"role": "user", "content": text},
                 ],
                 "chat_template_kwargs": {"enable_thinking": False},
@@ -105,7 +108,7 @@ class Router:
         start = time.time()
         result = entry["resume"](step_callback)
         meta = entry["meta"]
-        self._update_history(meta.get("user_text", ""), result)
+        self._append_turn(meta.get("user_text", ""), result)
         return self._annotate(result, agent=meta.get("agent", "claude"),
                               model=meta.get("model", ""), escalated=False,
                               escalation_reason=None, intent_class=meta.get("intent_class"),
@@ -117,11 +120,15 @@ class Router:
         start = time.time()
         mode = self._routing_mode
 
+        if self._pending_compaction_notice and step_callback is not None:
+            step_callback({"type": "compacted", "message": "Context compacted."})
+            self._pending_compaction_notice = False
+
         # haiku_first: pre-flight classifies → Haiku for non-complex, Sonnet for complex_reasoning
         if mode == "haiku_first":
             classification = {"can_handle_locally": True, "intent_class": "read_only", "reason": "fallback"}
             try:
-                classification = self._classify(text)
+                classification = self._classify(text, history=self._history)
             except Exception as e:
                 logging.getLogger("jarvis.errors").warning(
                     f"Pre-flight classifier failed: {e} — using haiku"
@@ -136,7 +143,7 @@ class Router:
 
             result = agent.run(text, cwd=cwd, memory_context=memory_context, history=self._history, source=source,
                                step_callback=step_callback, command_id=command_id)
-            self._update_history(text, result)
+            self._append_turn(text, result)
             return self._annotate(result, agent="claude", model=model_name,
                                   escalated=False, escalation_reason=classification.get("reason"),
                                   intent_class=intent_class, start=start)
@@ -145,7 +152,7 @@ class Router:
         if mode == "local_first":
             classification = {"can_handle_locally": True, "intent_class": "read_only", "reason": "fallback"}
             try:
-                classification = self._classify(text)
+                classification = self._classify(text, history=self._history)
             except Exception as e:
                 logging.getLogger("jarvis.errors").warning(
                     f"Pre-flight classifier failed: {e} — using local executor"
@@ -155,7 +162,7 @@ class Router:
             if intent_class == "complex_reasoning":
                 result = self._sonnet.run(text, cwd=cwd, memory_context=memory_context, history=self._history,
                                           source=source, step_callback=step_callback, command_id=command_id)
-                self._update_history(text, result)
+                self._append_turn(text, result)
                 model_name = self._config.get("models", {}).get("sonnet", "claude-sonnet-4-6")
                 return self._annotate(result, agent="claude", model=model_name,
                                       escalated=False, escalation_reason=classification.get("reason"),
@@ -164,7 +171,7 @@ class Router:
             # Non-complex: use local OllamaAgent; escalate to Sonnet on failure
             try:
                 result = self._ollama.run(text, cwd=cwd, memory_context=memory_context, history=self._history, step_callback=step_callback, intent_class=intent_class, command_id=command_id)
-                self._update_history(text, result)
+                self._append_turn(text, result)
                 executor_model = self._config.get("ollama", {}).get("executor_model") or self._ollama_model
                 return self._annotate(result, agent="ollama", model=executor_model,
                                       escalated=False, escalation_reason=None,
@@ -175,7 +182,7 @@ class Router:
                 )
                 result = self._sonnet.run(text, cwd=cwd, memory_context=memory_context, history=self._history,
                                           ollama_available=False, source=source, step_callback=step_callback, command_id=command_id)
-                self._update_history(text, result)
+                self._append_turn(text, result)
                 model_name = self._config.get("models", {}).get("sonnet", "claude-sonnet-4-6")
                 return self._annotate(result, agent="claude", model=model_name,
                                       escalated=True, escalation_reason=e.reason,
@@ -185,7 +192,7 @@ class Router:
         if mode == "claude_only":
             result = self._claude.run(text, cwd=cwd, memory_context=memory_context, history=self._history, source=source,
                                       step_callback=step_callback, command_id=command_id)
-            self._update_history(text, result)
+            self._append_turn(text, result)
             return self._annotate(result, agent="claude", model="claude-sonnet-4-6",
                                   escalated=False, escalation_reason=None,
                                   intent_class=None, start=start)
@@ -193,7 +200,7 @@ class Router:
         # Pre-flight classification (ollama_first / ollama_only)
         classification = {"can_handle_locally": True, "intent_class": "read_only", "reason": "fallback"}
         try:
-            classification = self._classify(text)
+            classification = self._classify(text, history=self._history)
         except Exception as e:
             logging.getLogger("jarvis.errors").warning(
                 f"Pre-flight classifier failed: {e} — using ollama_first fallback"
@@ -206,7 +213,7 @@ class Router:
         if mode == "ollama_only" or can_handle_locally:
             try:
                 result = self._ollama.run(text, cwd=cwd, memory_context=memory_context, history=self._history, step_callback=step_callback, intent_class=intent_class, command_id=command_id)
-                self._update_history(text, result)
+                self._append_turn(text, result)
                 return self._annotate(result, agent="ollama", model=self._ollama_model,
                                       escalated=False, escalation_reason=None,
                                       intent_class=intent_class, start=start)
@@ -228,25 +235,86 @@ class Router:
         result = self._claude.run(text, cwd=cwd, memory_context=memory_context, history=self._history,
                                   ollama_available=(escalation_reason is None), source=source,
                                   step_callback=step_callback, command_id=command_id)
-        self._update_history(text, result)
+        self._append_turn(text, result)
         return self._annotate(result, agent="claude", model="claude-sonnet-4-6",
                               escalated=escalation_reason is not None,
                               escalation_reason=escalation_reason or classification.get("reason"),
                               intent_class=intent_class, start=start)
 
-    def _update_history(self, user_text: str, result: dict) -> None:
-        """Append the exchange to history. Skip if approval_required (command not completed)."""
+    def _append_turn(self, user_text: str, result: dict) -> None:
+        """Append a compressed turn to history. Skip if approval_required."""
         if result.get("approval_required"):
             return
-        assistant_text = result.get("display") or result.get("speak") or ""
-        if not assistant_text:
+        steps = result.get("steps") or []
+        if steps:
+            lines = ["Actions:"]
+            for s in steps:
+                tool = s.get("tool", "?")
+                inp = (s.get("input_summary") or "")[:200]
+                res = (s.get("result_summary") or "")[:200]
+                lines.append(f"- {tool}({inp}) → {res}")
+            result_text = result.get("speak") or result.get("display") or ""
+            lines.append(f"\nResult: {result_text}")
+            assistant_content = "\n".join(lines)
+        else:
+            assistant_content = result.get("display") or result.get("speak") or ""
+
+        if not assistant_content:
             return
+
         self._history.extend([
             {"role": "user", "content": user_text},
-            {"role": "assistant", "content": assistant_text},
+            {"role": "assistant", "content": assistant_content},
         ])
-        if len(self._history) > self._MAX_HISTORY:
-            self._history = self._history[-self._MAX_HISTORY:]
+
+        if self._estimate_tokens() > 5000:
+            self._compact()
+
+    def _estimate_tokens(self) -> int:
+        """Rough token estimate: 1 token ≈ 4 chars."""
+        return sum(len(m["content"]) for m in self._history) // 4
+
+    def _compact(self) -> None:
+        """Summarize _history with Haiku and replace it with a compact pair.
+        Best-effort: logs and continues on any failure."""
+        transcript_lines = []
+        for m in self._history:
+            role = m["role"].upper()
+            transcript_lines.append(f"{role}: {m['content']}")
+        transcript = "\n\n".join(transcript_lines)
+
+        haiku_model = self._config.get("models", {}).get("haiku", "claude-haiku-4-5-20251001")
+        prompt = (
+            "Summarize this conversation into a compact context block.\n"
+            "Include ALL of the following that are present:\n"
+            "- Active task and its current state\n"
+            "- Key entities with exact values: PR numbers, branch names, file paths, "
+            "error messages, usernames, URLs, check run IDs\n"
+            "- Actions taken and their outcomes (which tool calls produced useful results)\n"
+            "- What the user wants to happen next, if clear\n\n"
+            "Max 400 words. Be specific — preserve exact IDs and numeric values.\n\n"
+            f"CONVERSATION:\n{transcript}"
+        )
+
+        try:
+            response = self._anthropic_client.messages.create(
+                model=haiku_model,
+                max_tokens=600,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            summary = "".join(
+                b.text for b in response.content if hasattr(b, "text")
+            ).strip()
+            if not summary:
+                raise ValueError("Empty summary from Haiku")
+            self._history = [
+                {"role": "user", "content": "[Prior conversation compacted]"},
+                {"role": "assistant", "content": summary},
+            ]
+            self._pending_compaction_notice = True
+            logging.getLogger("jarvis.errors").info("Session history compacted.")
+        except Exception as e:
+            logging.getLogger("jarvis.errors").warning(f"History compaction failed (continuing): {e}")
 
     def _annotate(self, result: dict, agent: str, model: str,
                   escalated: bool, escalation_reason: str | None,

--- a/jarvis-core/router.py
+++ b/jarvis-core/router.py
@@ -29,10 +29,14 @@ class Router:
         self._claude = self._sonnet   # legacy alias for claude_only / ollama_first modes
         self._history: list[dict] = []
         self._pending_compaction_notice: bool = False
+        self._needs_compaction: bool = False
+        self._compact_failed: bool = False
         self._anthropic_client = _anthropic.Anthropic(api_key=config.get("anthropic_api_key", ""))
 
     def reset_conversation(self) -> None:
         self._history = []
+        self._needs_compaction = False
+        self._compact_failed = False
 
         mode = self._config.get("ollama", {}).get("routing_mode", "ollama_first")
         if mode not in _VALID_ROUTING_MODES:
@@ -119,6 +123,12 @@ class Router:
         """Route a command via pre-flight classifier and return response with metadata."""
         start = time.time()
         mode = self._routing_mode
+
+        # Deferred compaction: runs at the START of the next command so it doesn't
+        # block the previous command's final SSE event ("complete").
+        if self._needs_compaction and not self._compact_failed:
+            self._needs_compaction = False
+            self._compact()
 
         if self._pending_compaction_notice and step_callback is not None:
             step_callback({"type": "compacted", "message": "Context compacted."})
@@ -267,8 +277,8 @@ class Router:
             {"role": "assistant", "content": assistant_content},
         ])
 
-        if self._estimate_tokens() > 5000:
-            self._compact()
+        if not self._compact_failed and self._estimate_tokens() > 5000:
+            self._needs_compaction = True  # compact at start of next process() call
 
     def _estimate_tokens(self) -> int:
         """Rough token estimate: 1 token ≈ 4 chars."""
@@ -314,7 +324,8 @@ class Router:
             self._pending_compaction_notice = True
             logging.getLogger("jarvis.errors").info("Session history compacted.")
         except Exception as e:
-            logging.getLogger("jarvis.errors").warning(f"History compaction failed (continuing): {e}")
+            self._compact_failed = True  # circuit breaker: don't retry until reset_conversation()
+            logging.getLogger("jarvis.errors").warning(f"History compaction failed (disabled until reset): {e}")
 
     def _annotate(self, result: dict, agent: str, model: str,
                   escalated: bool, escalation_reason: str | None,

--- a/jarvis-core/server.py
+++ b/jarvis-core/server.py
@@ -274,6 +274,10 @@ def _log_command_result(req: "CommandRequest", start: float, result: dict, *, re
             "escalated": result.get("_escalated"),
             "escalation_reason": result.get("_escalation_reason"),
             "agent_response_ms": result.get("_response_ms"),
+            "ttft_ms": result.get("ttft_ms"),
+            "gen_tokens": result.get("tokens"),
+            "gen_ms": result.get("gen_ms"),
+            "tok_s": result.get("tok_s"),
         })
         logger_module.log_training(
             _loggers["training"],

--- a/jarvis-core/tests/test_agent.py
+++ b/jarvis-core/tests/test_agent.py
@@ -851,3 +851,73 @@ def test_agent_passes_mcp_manager_to_execute_tool():
             agent.run("list issues")
 
     assert captured.get("mcp_manager") is mgr
+
+
+# ── Task 11: result_summary cap and wrap-up nudge ─────────────────────────────
+
+def test_result_summary_capped_at_200_chars():
+    agent = make_agent()
+    long_result = "x" * 300
+
+    tool_block = MagicMock()
+    tool_block.type = "tool_use"
+    tool_block.name = "shell_run"
+    tool_block.input = {"command": "echo hi"}
+    tool_block.id = "tu_1"
+
+    text_block = MagicMock()
+    text_block.type = "text"
+    text_block.text = "Done."
+
+    first_resp = MagicMock(stop_reason="tool_use", content=[tool_block])
+    second_resp = MagicMock(stop_reason="end_turn", content=[text_block])
+
+    with patch.object(agent._client.messages, "create", side_effect=[first_resp, second_resp]):
+        with patch("agent.execute_tool", return_value=long_result):
+            result = agent.run("run echo hi")
+
+    assert len(result["steps"][0]["result_summary"]) <= 200
+
+
+def test_wrap_up_nudge_injected_near_step_limit():
+    agent = make_agent()
+    agent._config["reasoning"] = {"max_steps_claude": 5}
+
+    # Return tool calls for first 3 iterations, then end_turn
+    def make_tool_resp(n):
+        b = MagicMock()
+        b.type = "tool_use"
+        b.name = "shell_run"
+        b.input = {"command": f"ls /tmp/{n}"}
+        b.id = f"tu_{n}"
+        r = MagicMock(stop_reason="tool_use", content=[b])
+        return r
+
+    text_block = MagicMock()
+    text_block.type = "text"
+    text_block.text = "Done."
+    final_resp = MagicMock(stop_reason="end_turn", content=[text_block])
+
+    captured_messages = []
+    call_count = [0]
+
+    def fake_create(**kwargs):
+        captured_messages.append([m for m in kwargs.get("messages", [])])
+        n = call_count[0]
+        call_count[0] += 1
+        if n < 3:
+            return make_tool_resp(n)
+        return final_resp
+
+    with patch.object(agent._client.messages, "create", side_effect=fake_create):
+        with patch("agent.execute_tool", return_value="ok"):
+            agent.run("do lots of stuff")
+
+    # The 4th API call (index 3) should have the nudge in messages
+    assert call_count[0] >= 4
+    fourth_call_messages = captured_messages[3]
+    nudge_found = any(
+        isinstance(m.get("content"), str) and "approaching your step limit" in m["content"]
+        for m in fourth_call_messages
+    )
+    assert nudge_found, "wrap-up nudge not found in messages passed to 4th API call"

--- a/jarvis-core/tests/test_config.py
+++ b/jarvis-core/tests/test_config.py
@@ -95,9 +95,10 @@ def test_load_deep_merges_ollama(tmp_path, monkeypatch):
 def test_defaults_include_reasoning_block(tmp_path, monkeypatch):
     monkeypatch.setattr("config.CONFIG_PATH", tmp_path / "config.json")
     cfg = config.load()
-    assert cfg["reasoning"]["max_steps_claude"] == 10
-    assert cfg["reasoning"]["max_steps_ollama"] == 10
-    assert cfg["reasoning"]["max_total_steps"] == 20
+    assert cfg["reasoning"]["max_steps_claude"] == 15
+    assert cfg["reasoning"]["max_steps_ollama"] == 15
+    assert "max_total_steps" not in cfg["reasoning"]
+    assert "step_budgets" not in cfg["reasoning"]
     assert cfg["reasoning"]["stall_detection"] is True
 
 
@@ -114,7 +115,7 @@ def test_load_deep_merges_reasoning(tmp_path, monkeypatch):
     }))
     cfg = config.load()
     assert cfg["reasoning"]["max_steps_claude"] == 10
-    assert cfg["reasoning"]["max_total_steps"] == 20   # default preserved
+    assert cfg["reasoning"]["max_steps_ollama"] == 15  # default preserved
 
 
 def test_config_has_models_section(tmp_path, monkeypatch):

--- a/jarvis-core/tests/test_ollama_agent.py
+++ b/jarvis-core/tests/test_ollama_agent.py
@@ -844,3 +844,33 @@ def test_planning_text_escalates_after_2_retries(agent):
             from ollama_agent import EscalateToCloud
             with pytest.raises(EscalateToCloud):
                 agent.run("check something")
+
+
+def test_planning_text_after_tool_calls_triggers_nudge(agent):
+    """Model makes some tool calls, then returns planning text — should get nudged, not exit."""
+    responses = [
+        _tool_response("mcp__github__list_pull_requests", {"owner": "matanvilensky", "repo": "jarvis"}),
+        # After the tool call, model returns planning text instead of next tool or finalize
+        _stop_response("Let me check for PRs in the repo and review the local branch changes."),
+        # After nudge, model calls the corrected tool
+        _tool_response("mcp__github__list_pull_requests", {"owner": "Matanvil", "repo": "jarvis"}),
+        _stop_response("PR #39 is open: feat: Phase E."),
+    ]
+    idx = [0]
+    nudge_fired = [False]
+
+    def fake_post(url, json=None, **kwargs):
+        r = responses[idx[0]]; idx[0] += 1; return r
+
+    def fake_step(event):
+        if event.get("type") == "clear":
+            nudge_fired[0] = True
+
+    stream_mock = MagicMock(side_effect=ValueError("force fallback"))
+    with patch.object(agent._http_client, "stream", stream_mock):
+        with patch.object(agent._http_client, "post", side_effect=fake_post):
+            with patch("ollama_agent.execute_tool", return_value='[{"number":39}]'):
+                result = agent.run("check PRs", step_callback=fake_step)
+
+    assert nudge_fired[0], "clear SSE not emitted when planning text followed tool calls"
+    assert "PR #39" in result["speak"]

--- a/jarvis-core/tests/test_ollama_agent.py
+++ b/jarvis-core/tests/test_ollama_agent.py
@@ -797,3 +797,50 @@ def test_ollama_wrap_up_nudge_injected_near_step_limit(agent):
         for m in call_payloads[3]["messages"]
     )
     assert nudge_found, "wrap-up nudge not found in 4th API call's messages"
+
+
+# ── planning text nudge ───────────────────────────────────────────────────────
+
+def test_planning_text_triggers_nudge_then_tool_call(agent):
+    """Model returns 'Let me check...' first, then a real tool call after nudge."""
+    from ollama_agent import _is_planning_text
+    assert _is_planning_text("Let me fetch the PR diff.")
+    assert _is_planning_text("I'll check the CI failures for you.")
+    assert not _is_planning_text("Done.")
+    assert not _is_planning_text("Your Downloads folder is empty.")
+
+    responses = [
+        _stop_response("Let me check the CI failures for you."),  # planning text, no tools
+        _tool_response("shell_run", {"command": "gh pr view 38 --json statusCheckRollup"}),
+        _stop_response("CI failed due to missing mcp module."),
+    ]
+    idx = [0]
+    captured_nudge = [False]
+
+    def fake_post(url, json=None, **kwargs):
+        r = responses[idx[0]]; idx[0] += 1; return r
+
+    def fake_step(event):
+        if event.get("type") == "clear":
+            captured_nudge[0] = True
+
+    stream_mock = MagicMock(side_effect=ValueError("force fallback"))
+    with patch.object(agent._http_client, "stream", stream_mock):
+        with patch.object(agent._http_client, "post", side_effect=fake_post):
+            with patch("ollama_agent.execute_tool", return_value="ok"):
+                result = agent.run("check CI", step_callback=fake_step)
+
+    assert captured_nudge[0], "clear SSE event not emitted on nudge"
+    assert result["speak"] == "CI failed due to missing mcp module."
+    assert len(result["steps"]) >= 1
+
+
+def test_planning_text_escalates_after_2_retries(agent):
+    """If the model returns planning text 3 times (0 tool calls), escalate to cloud."""
+    stream_mock = MagicMock(side_effect=ValueError("force fallback"))
+    with patch.object(agent._http_client, "stream", stream_mock):
+        with patch.object(agent._http_client, "post",
+                          return_value=_stop_response("Let me check that for you.")):
+            from ollama_agent import EscalateToCloud
+            with pytest.raises(EscalateToCloud):
+                agent.run("check something")

--- a/jarvis-core/tests/test_ollama_agent.py
+++ b/jarvis-core/tests/test_ollama_agent.py
@@ -327,88 +327,10 @@ def test_finalize_tool_stops_before_step_limit(agent):
     assert len(result["steps"]) == 2
 
 
-# ── intent-class based step budgets ──────────────────────────────────────────
+# ── max_steps_ollama controls step limit ──────────────────────────────────────
 
-def test_read_only_intent_uses_lower_step_budget(agent):
-    """read_only intent_class uses step_budgets.read_only (5) not max_steps_ollama (10)."""
-    call_count = [0]
-    commands = [f"ls /dir{i}" for i in range(20)]
-
-    def fake_post(url, json=None, **kwargs):
-        call_count[0] += 1
-        resp = MagicMock()
-        resp.raise_for_status = MagicMock()
-        if json and json.get("tool_choice") == "none":
-            resp.json.return_value = {"choices": [{"finish_reason": "stop",
-                                                    "message": {"content": "Done."}}]}
-        else:
-            cmd = commands[call_count[0] % len(commands)]
-            resp.json.return_value = {"choices": [{"finish_reason": "tool_calls", "message": {
-                "content": None,
-                "tool_calls": [{"id": f"c{call_count[0]}", "function": {
-                    "name": "shell_run", "arguments": f'{{"command": "{cmd}"}}'
-                }}]
-            }}]}
-        return resp
-
-    agent._config["reasoning"]["max_steps_ollama"] = 10
-    agent._config["reasoning"]["step_budgets"] = {
-        "read_only": 5, "prepare": 8, "destructive": 10, "complex_reasoning": 10
-    }
-    with patch.object(agent._http_client, "post", side_effect=fake_post):
-        with patch("ollama_agent.execute_tool", return_value="ok"):
-            agent.run("list files", intent_class="read_only")
-
-    # 5 tool calls + 1 salvage = ≤ 7 total API calls
-    assert call_count[0] <= 7
-
-
-def test_destructive_intent_uses_higher_step_budget(agent):
-    """destructive intent_class uses step_budgets.destructive (10), not read_only (3)."""
-    call_count = [0]
-    # Alternate tools so near-duplicate detection (same tool ≥ 3 times) doesn't fire
-    tools_cycle = ["shell_run", "file_read", "shell_run", "file_read",
-                   "shell_run", "file_read", "shell_run", "file_read",
-                   "shell_run", "file_read", "shell_run"]
-    args_cycle = [
-        '{"command": "rm /tmp/a"}', '{"path": "/tmp/a.log"}',
-        '{"command": "rm /tmp/b"}', '{"path": "/tmp/b.log"}',
-        '{"command": "rm /tmp/c"}', '{"path": "/tmp/c.log"}',
-        '{"command": "rm /tmp/d"}', '{"path": "/tmp/d.log"}',
-        '{"command": "rm /tmp/e"}', '{"path": "/tmp/e.log"}',
-        '{"command": "rm /tmp/f"}',
-    ]
-
-    def fake_post(url, json=None, **kwargs):
-        call_count[0] += 1
-        resp = MagicMock()
-        resp.raise_for_status = MagicMock()
-        if json and json.get("tool_choice") == "none":
-            resp.json.return_value = {"choices": [{"finish_reason": "stop",
-                                                    "message": {"content": "Deleted."}}]}
-        else:
-            idx = (call_count[0] - 1) % len(tools_cycle)
-            resp.json.return_value = {"choices": [{"finish_reason": "tool_calls", "message": {
-                "content": None,
-                "tool_calls": [{"id": f"c{call_count[0]}", "function": {
-                    "name": tools_cycle[idx], "arguments": args_cycle[idx]
-                }}]
-            }}]}
-        return resp
-
-    agent._config["reasoning"]["step_budgets"] = {
-        "read_only": 3, "prepare": 8, "destructive": 10, "complex_reasoning": 10
-    }
-    with patch.object(agent._http_client, "post", side_effect=fake_post):
-        with patch("ollama_agent.execute_tool", return_value="ok"):
-            agent.run("delete temp files", intent_class="destructive")
-
-    # destructive budget=10 → more API calls than read_only budget=3 would allow (4 max)
-    assert call_count[0] > 4
-
-
-def test_no_intent_class_uses_max_steps_ollama(agent):
-    """Without intent_class, falls back to max_steps_ollama."""
+def test_max_steps_ollama_controls_step_limit(agent):
+    """max_steps_ollama limits total tool calls regardless of intent_class."""
     call_count = [0]
     commands = [f"ls /dir{i}" for i in range(20)]
 
@@ -430,13 +352,12 @@ def test_no_intent_class_uses_max_steps_ollama(agent):
         return resp
 
     agent._config["reasoning"]["max_steps_ollama"] = 3
-    agent._config["reasoning"]["step_budgets"] = {"read_only": 1}
     with patch.object(agent._http_client, "post", side_effect=fake_post):
         with patch("ollama_agent.execute_tool", return_value="ok"):
-            agent.run("do something")  # no intent_class → uses max_steps_ollama=3
+            agent.run("do something")
 
-    # 3 tool calls + 1 salvage = ≤ 5 total; more than 1 (which read_only budget would give)
-    assert call_count[0] > 2
+    # 3 tool calls + salvage = ≤ 5 total API calls
+    assert call_count[0] <= 5
 
 
 def test_finalize_tool_is_in_ollama_tools_schema(agent):
@@ -817,3 +738,62 @@ def test_ollama_agent_passes_mcp_manager_to_execute_tool():
             a.run("list issues")
 
     assert captured.get("mcp_manager") is mgr
+
+
+# ── Task 12: result_summary cap and wrap-up nudge ─────────────────────────────
+
+def test_ollama_result_summary_capped_at_200_chars(agent):
+    long_result = "y" * 300
+    tool_resp = _tool_response("shell_run", {"command": "ls"})
+    stop_resp = _stop_response("Done.")
+
+    responses = [tool_resp, stop_resp]
+    idx = [0]
+    def fake_post(url, json=None, **kwargs):
+        r = responses[idx[0]]; idx[0] += 1; return r
+
+    stream_mock = MagicMock(side_effect=ValueError("force fallback to post"))
+    with patch.object(agent._http_client, "stream", stream_mock):
+        with patch.object(agent._http_client, "post", side_effect=fake_post):
+            with patch("ollama_agent.execute_tool", return_value=long_result):
+                result = agent.run("list files")
+
+    assert len(result["steps"][0]["result_summary"]) <= 200
+
+
+def test_ollama_wrap_up_nudge_injected_near_step_limit(agent):
+    agent._config["reasoning"]["max_steps_ollama"] = 5
+    agent._config["reasoning"]["stall_detection"] = False  # avoid near-dup terminating early
+    call_payloads = []
+    # Alternate tool names to also avoid near-duplicate detection
+    tools_cycle = ["shell_run", "file_read", "shell_run", "file_read"]
+
+    def fake_post(url, json=None, **kwargs):
+        call_payloads.append(json)
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        n = len(call_payloads)
+        if n >= 4:
+            resp.json.return_value = {"choices": [{"finish_reason": "stop",
+                                                    "message": {"content": "Done.", "tool_calls": None}}]}
+        else:
+            tool_name = tools_cycle[(n - 1) % len(tools_cycle)]
+            args = f'{{"command": "ls /tmp/{n}"}}' if tool_name == "shell_run" else f'{{"path": "/tmp/{n}.txt"}}'
+            resp.json.return_value = {"choices": [{"finish_reason": "tool_calls", "message": {
+                "content": None,
+                "tool_calls": [{"id": f"c{n}", "function": {"name": tool_name, "arguments": args}}]
+            }}]}
+        return resp
+
+    stream_mock = MagicMock(side_effect=ValueError("force fallback to post"))
+    with patch.object(agent._http_client, "stream", stream_mock):
+        with patch.object(agent._http_client, "post", side_effect=fake_post):
+            with patch("ollama_agent.execute_tool", return_value="ok"):
+                agent.run("do stuff")
+
+    assert len(call_payloads) >= 4
+    nudge_found = any(
+        "approaching your step limit" in (m.get("content") or "")
+        for m in call_payloads[3]["messages"]
+    )
+    assert nudge_found, "wrap-up nudge not found in 4th API call's messages"

--- a/jarvis-core/tests/test_ollama_agent.py
+++ b/jarvis-core/tests/test_ollama_agent.py
@@ -846,6 +846,61 @@ def test_planning_text_escalates_after_2_retries(agent):
                 agent.run("check something")
 
 
+def _make_streaming_finalize_response(answer: str, call_id: str = "call_fin"):
+    """Build SSE lines simulating a streaming finalize(answer=...) tool call."""
+    args_str = _json_mod.dumps({"answer": answer})
+    mid = len(args_str) // 2
+    return [
+        f'data: {_json_mod.dumps({"choices": [{"delta": {"role": "assistant", "content": "", "tool_calls": [{"index": 0, "id": call_id, "type": "function", "function": {"name": "finalize", "arguments": ""}}]}, "finish_reason": None}]})}',
+        f'data: {_json_mod.dumps({"choices": [{"delta": {"tool_calls": [{"index": 0, "function": {"arguments": args_str[:mid]}}]}, "finish_reason": None}]})}',
+        f'data: {_json_mod.dumps({"choices": [{"delta": {"tool_calls": [{"index": 0, "function": {"arguments": args_str[mid:]}}]}, "finish_reason": None}]})}',
+        f'data: {_json_mod.dumps({"choices": [{"delta": {}, "finish_reason": "tool_calls"}]})}',
+        "data: [DONE]",
+    ]
+
+
+def test_finalize_streams_answer_as_tokens(agent):
+    """When Ollama calls finalize(answer=...), the answer must be streamed as token events."""
+    from ollama_agent import _stream_call
+    answer = "Here is your code review: looks great overall."
+    lines = _make_streaming_finalize_response(answer)
+
+    events = []
+    with patch.object(agent._http_client, "stream", return_value=_mock_stream(lines)):
+        _stream_call(agent._http_client, "http://localhost/v1/chat/completions",
+                     {"model": "test", "messages": [], "tools": []},
+                     step_callback=lambda e: events.append(e))
+
+    token_events = [e for e in events if e.get("type") == "token"]
+    assert len(token_events) > 0, "Expected token events from finalize answer"
+    assembled = "".join(e["text"] for e in token_events)
+    assert answer in assembled or assembled in answer, (
+        f"Assembled tokens '{assembled}' do not match expected answer '{answer}'"
+    )
+
+
+def test_finalize_emits_composing_step_before_tokens(agent):
+    """A 'Composing response…' step event must fire before the first token of a finalize answer."""
+    from ollama_agent import _stream_call
+    lines = _make_streaming_finalize_response("The answer is 42.")
+
+    events = []
+    composing_state = [False]
+    with patch.object(agent._http_client, "stream", return_value=_mock_stream(lines)):
+        _stream_call(agent._http_client, "http://localhost/v1/chat/completions",
+                     {"model": "test", "messages": [], "tools": []},
+                     step_callback=lambda e: events.append(e),
+                     composing_state=composing_state)
+
+    step_events = [e for e in events if e.get("type") == "step"]
+    composing = [e for e in step_events if e.get("label") == "Composing response…"]
+    assert composing, "Expected 'Composing response…' step event for finalize call"
+
+    first_token_idx = next((i for i, e in enumerate(events) if e.get("type") == "token"), len(events))
+    composing_idx = next(i for i, e in enumerate(events) if e.get("label") == "Composing response…")
+    assert composing_idx < first_token_idx, "Composing step must fire before first token"
+
+
 def test_planning_text_after_tool_calls_triggers_nudge(agent):
     """Model makes some tool calls, then returns planning text — should get nudged, not exit."""
     responses = [

--- a/jarvis-core/tests/test_router.py
+++ b/jarvis-core/tests/test_router.py
@@ -444,3 +444,101 @@ def test_classify_reuses_shared_http_client(config):
     r = Router(config=config, guardrails=guardrails)
     assert hasattr(r, "_http_client"), "Router must have a shared _http_client"
     assert r._http_client is not None
+
+
+# ── Task 9: _append_turn, compaction, classifier context ─────────────────────
+
+def test_append_turn_stores_compressed_steps(haiku_router):
+    result = {
+        "speak": "Done.",
+        "display": "Done with details.",
+        "steps": [
+            {"tool": "shell_run", "input_summary": "git log --oneline", "result_summary": "abc1234 fix: prevent crash"},
+            {"tool": "file_read", "input_summary": "/tmp/x.py", "result_summary": "def main(): pass"},
+        ],
+    }
+    haiku_router._append_turn("show me the log", result)
+    assistant_content = haiku_router._history[-1]["content"]
+    assert "shell_run" in assistant_content
+    assert "abc1234 fix: prevent crash" in assistant_content
+    assert "file_read" in assistant_content
+
+
+def test_append_turn_skips_approval_required(haiku_router):
+    result = {"approval_required": {"tool": "shell_run"}, "steps": []}
+    haiku_router._append_turn("delete stuff", result)
+    assert haiku_router._history == []
+
+
+def test_append_turn_no_steps_stores_display_text(haiku_router):
+    result = {"speak": "Hi there!", "display": "Hi there!", "steps": []}
+    haiku_router._append_turn("hello", result)
+    assert haiku_router._history[-1]["content"] == "Hi there!"
+
+
+def test_classify_receives_history_context(config):
+    config["ollama"]["routing_mode"] = "local_first"
+    guardrails = Guardrails(config)
+    r = Router(config=config, guardrails=guardrails)
+    history = [
+        {"role": "user", "content": "check CI"},
+        {"role": "assistant", "content": "CI is failing on test_foo"},
+    ]
+    captured = {}
+
+    def fake_post(url, json=None, **kwargs):
+        captured["json"] = json
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"choices": [{"message": {"content": '{"intent_class":"prepare","can_handle_locally":true}'}}]}
+        return resp
+
+    with patch.object(r._http_client, "post", side_effect=fake_post):
+        r._classify("yes please", history=history)
+
+    messages = captured["json"]["messages"]
+    roles = [m["role"] for m in messages]
+    assert roles == ["system", "user", "assistant", "user"]
+    assert messages[-1]["content"] == "yes please"
+
+
+def test_compact_fires_when_tokens_exceed_threshold(haiku_router):
+    large_content = "x" * 20001  # ~5000 tokens
+    haiku_router._history = [
+        {"role": "user", "content": large_content},
+        {"role": "assistant", "content": "response"},
+    ]
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="Compact summary of the session.")]
+
+    with patch.object(haiku_router._anthropic_client.messages, "create", return_value=mock_response):
+        haiku_router._append_turn("another command", {"speak": "ok", "display": "ok", "steps": []})
+
+    assert len(haiku_router._history) == 2
+    assert haiku_router._history[0]["content"] == "[Prior conversation compacted]"
+    assert "Compact summary" in haiku_router._history[1]["content"]
+    assert haiku_router._pending_compaction_notice is True
+
+
+def test_compact_best_effort_on_failure(haiku_router):
+    haiku_router._history = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "world"},
+    ]
+    original_history = list(haiku_router._history)
+    with patch.object(haiku_router._anthropic_client.messages, "create", side_effect=Exception("network error")):
+        haiku_router._compact()
+
+    assert haiku_router._history == original_history
+    assert haiku_router._pending_compaction_notice is False
+
+
+def test_compaction_notice_emitted_on_next_process(haiku_router, mock_haiku_agent):
+    haiku_router._pending_compaction_notice = True
+    events = []
+    mock_haiku_agent.run.return_value = {"speak": "ok", "display": "ok", "steps": []}
+    with patch.object(haiku_router, "_classify", return_value={"intent_class": "read_only", "can_handle_locally": True}):
+        haiku_router.process("do something", step_callback=events.append)
+
+    assert any(e.get("type") == "compacted" for e in events)
+    assert haiku_router._pending_compaction_notice is False

--- a/jarvis-core/tests/test_router.py
+++ b/jarvis-core/tests/test_router.py
@@ -502,7 +502,8 @@ def test_classify_receives_history_context(config):
     assert messages[-1]["content"] == "yes please"
 
 
-def test_compact_fires_when_tokens_exceed_threshold(haiku_router):
+def test_compact_fires_when_tokens_exceed_threshold(haiku_router, mock_haiku_agent):
+    """Compaction is deferred: _append_turn sets the flag; process() triggers it."""
     large_content = "x" * 20001  # ~5000 tokens
     haiku_router._history = [
         {"role": "user", "content": large_content},
@@ -510,11 +511,18 @@ def test_compact_fires_when_tokens_exceed_threshold(haiku_router):
     ]
     mock_response = MagicMock()
     mock_response.content = [MagicMock(text="Compact summary of the session.")]
+    mock_haiku_agent.run.return_value = {"speak": "next", "display": "next", "steps": []}
 
+    # First: _append_turn should set the deferred flag but NOT compact yet.
+    haiku_router._append_turn("another command", {"speak": "ok", "display": "ok", "steps": []})
+    assert haiku_router._needs_compaction is True
+    assert len(haiku_router._history) == 4  # not compacted yet
+
+    # Second: process() triggers the deferred compact at its start.
     with patch.object(haiku_router._anthropic_client.messages, "create", return_value=mock_response):
-        haiku_router._append_turn("another command", {"speak": "ok", "display": "ok", "steps": []})
+        haiku_router.process("next command")
 
-    assert len(haiku_router._history) == 2
+    assert len(haiku_router._history) == 4  # 2 compact + 2 new from process()
     assert haiku_router._history[0]["content"] == "[Prior conversation compacted]"
     assert "Compact summary" in haiku_router._history[1]["content"]
     assert haiku_router._pending_compaction_notice is True
@@ -531,6 +539,7 @@ def test_compact_best_effort_on_failure(haiku_router):
 
     assert haiku_router._history == original_history
     assert haiku_router._pending_compaction_notice is False
+    assert haiku_router._compact_failed is True  # circuit breaker set
 
 
 def test_compaction_notice_emitted_on_next_process(haiku_router, mock_haiku_agent):

--- a/jarvis-swift/Jarvis/AudioController.swift
+++ b/jarvis-swift/Jarvis/AudioController.swift
@@ -197,23 +197,25 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
 
     private func startStreamTimerIfNeeded() {
         guard streamTimer == nil else { return }
-        NSLog("[Jarvis] streamTimer START — queueLen=%d", viewModel.tokenQueue.count)
         streamTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 15.0, repeats: true) { [weak self] _ in
-            MainActor.assumeIsolated {
+            // Timer fires on the main RunLoop (main thread). Use Task @MainActor to
+            // access @MainActor-isolated properties with a static guarantee.
+            Task { @MainActor [weak self] in
                 guard let self else { return }
-                let qBefore = self.viewModel.tokenQueue.count
-                let hasMore = self.viewModel.drainTokenQueue(chars: 8)
-                NSLog("[Jarvis] timerTick qBefore=%d hasMore=%d bufLen=%d", qBefore, hasMore ? 1 : 0, self.viewModel.streamingBuffer.count)
+                // Flush the full queue immediately once complete is pending — no point
+                // in throttling after the model has finished generating.
+                let drainSize = self.pendingCompleteEvent != nil
+                    ? self.viewModel.tokenQueue.count
+                    : 20
+                let hasMore = self.viewModel.drainTokenQueue(chars: drainSize)
                 self.showHUD(.response(text: self.viewModel.streamingBuffer))
                 if !hasMore {
                     if let event = self.pendingCompleteEvent {
-                        NSLog("[Jarvis] streamTimer DONE — finalizing via pending complete")
                         self.pendingCompleteEvent = nil
                         self.stopStreamTimer()
                         self.viewModel.clearStreamingBuffer()
                         self.finalizeComplete(event: event)
                     } else {
-                        NSLog("[Jarvis] streamTimer DONE — no pending complete")
                         self.stopStreamTimer()
                     }
                 }
@@ -423,19 +425,21 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
             let token = event["text"] as? String ?? ""
             if !token.isEmpty {
                 viewModel.appendToken(token)
-                NSLog("[Jarvis] token arrived len=%d queueTotal=%d", token.count, viewModel.tokenQueue.count)
                 startStreamTimerIfNeeded()
             }
         case "complete":
             if streamTimer != nil {
-                NSLog("[Jarvis] complete deferred — timer running, queueLen=%d", viewModel.tokenQueue.count)
+                // Timer is still draining — defer finalization until queue is empty.
                 pendingCompleteEvent = event
             } else {
-                NSLog("[Jarvis] complete immediate — no timer, queueLen=%d", viewModel.tokenQueue.count)
                 viewModel.clearStreamingBuffer()
                 finalizeComplete(event: event)
             }
         case "error":
+            // Cancel any pending stream state so it doesn't bleed into the next command.
+            stopStreamTimer()
+            pendingCompleteEvent = nil
+            viewModel.clearStreamingBuffer()
             let msg = event["message"] as? String ?? "Something went wrong."
             viewModel.finalizeTurn(response: "Error: \(msg)")
             showHUD(.response(text: msg))

--- a/jarvis-swift/Jarvis/AudioController.swift
+++ b/jarvis-swift/Jarvis/AudioController.swift
@@ -379,6 +379,9 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
             if stepVoice, milestone {
                 speak(label)
             }
+        case "clear":
+            viewModel.clearStreamingBuffer()
+            showHUD(.executing(step: "Working…"))
         case "token":
             let token = event["text"] as? String ?? ""
             if !token.isEmpty {

--- a/jarvis-swift/Jarvis/AudioController.swift
+++ b/jarvis-swift/Jarvis/AudioController.swift
@@ -26,6 +26,8 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
     private var recognitionTask: SFSpeechRecognitionTask?
     private let audioEngine = AVAudioEngine()
     private var silenceTimer: Timer?
+    private var streamTimer: Timer?
+    private var pendingCompleteEvent: [String: Any]?
     private var isListening = false
     private var pendingToolUseId: String?
     private var pendingApprovalCategory: String?
@@ -191,6 +193,39 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
         recognitionRequest = nil
     }
 
+    // MARK: - Stream display timer (15 fps, drains tokenQueue → streamingBuffer)
+
+    private func startStreamTimerIfNeeded() {
+        guard streamTimer == nil else { return }
+        NSLog("[Jarvis] streamTimer START — queueLen=%d", viewModel.tokenQueue.count)
+        streamTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 15.0, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                let qBefore = self.viewModel.tokenQueue.count
+                let hasMore = self.viewModel.drainTokenQueue(chars: 8)
+                NSLog("[Jarvis] timerTick qBefore=%d hasMore=%d bufLen=%d", qBefore, hasMore ? 1 : 0, self.viewModel.streamingBuffer.count)
+                self.showHUD(.response(text: self.viewModel.streamingBuffer))
+                if !hasMore {
+                    if let event = self.pendingCompleteEvent {
+                        NSLog("[Jarvis] streamTimer DONE — finalizing via pending complete")
+                        self.pendingCompleteEvent = nil
+                        self.stopStreamTimer()
+                        self.viewModel.clearStreamingBuffer()
+                        self.finalizeComplete(event: event)
+                    } else {
+                        NSLog("[Jarvis] streamTimer DONE — no pending complete")
+                        self.stopStreamTimer()
+                    }
+                }
+            }
+        }
+    }
+
+    private func stopStreamTimer() {
+        streamTimer?.invalidate()
+        streamTimer = nil
+    }
+
     private func scheduleSilenceTimeout() {
         silenceTimer?.invalidate()
         silenceTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { [weak self] _ in
@@ -353,6 +388,7 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
                             if let data = jsonStr.data(using: .utf8),
                                let event = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
                                 handleSSEEvent(event, stepVoice: stepVoice)
+                                await Task.yield()
                             }
                         }
                     }
@@ -380,24 +416,24 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
                 speak(label)
             }
         case "clear":
+            stopStreamTimer()
             viewModel.clearStreamingBuffer()
             showHUD(.executing(step: "Working…"))
         case "token":
             let token = event["text"] as? String ?? ""
             if !token.isEmpty {
                 viewModel.appendToken(token)
-                showHUD(.response(text: viewModel.streamingBuffer))
+                NSLog("[Jarvis] token arrived len=%d queueTotal=%d", token.count, viewModel.tokenQueue.count)
+                startStreamTimerIfNeeded()
             }
         case "complete":
-            viewModel.clearStreamingBuffer()
-            if let data = try? JSONSerialization.data(withJSONObject: event),
-               let response = try? JSONDecoder().decode(CommandResponse.self, from: data) {
-                viewModel.finalizeTurn(response: response.text)
-                handleCommandResponse(response)
+            if streamTimer != nil {
+                NSLog("[Jarvis] complete deferred — timer running, queueLen=%d", viewModel.tokenQueue.count)
+                pendingCompleteEvent = event
             } else {
-                let text = event["display"] as? String ?? event["speak"] as? String ?? "Done."
-                viewModel.finalizeTurn(response: text)
-                showHUD(.response(text: text))
+                NSLog("[Jarvis] complete immediate — no timer, queueLen=%d", viewModel.tokenQueue.count)
+                viewModel.clearStreamingBuffer()
+                finalizeComplete(event: event)
             }
         case "error":
             let msg = event["message"] as? String ?? "Something went wrong."
@@ -414,6 +450,18 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
             }
         default:
             break
+        }
+    }
+
+    private func finalizeComplete(event: [String: Any]) {
+        if let data = try? JSONSerialization.data(withJSONObject: event),
+           let response = try? JSONDecoder().decode(CommandResponse.self, from: data) {
+            viewModel.finalizeTurn(response: response.text)
+            handleCommandResponse(response)
+        } else {
+            let text = event["display"] as? String ?? event["speak"] as? String ?? "Done."
+            viewModel.finalizeTurn(response: text)
+            showHUD(.response(text: text))
         }
     }
 

--- a/jarvis-swift/Jarvis/AudioController.swift
+++ b/jarvis-swift/Jarvis/AudioController.swift
@@ -401,6 +401,14 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
             viewModel.finalizeTurn(response: "Error: \(msg)")
             showHUD(.response(text: msg))
             speak(msg)
+        case "compacted":
+            let msg = event["message"] as? String ?? "Context compacted."
+            showHUD(.response(text: msg))
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                guard let self else { return }
+                self.showHUD(.hidden)
+            }
         default:
             break
         }

--- a/jarvis-swift/Jarvis/HUDView.swift
+++ b/jarvis-swift/Jarvis/HUDView.swift
@@ -131,7 +131,7 @@ struct HUDView: View {
                     if case .approval = viewModel.state { return }
                     withAnimation { proxy.scrollTo("bottom", anchor: .bottom) }
                 }
-                .onChange(of: viewModel.streamingBuffer) { _ in
+                .onChange(of: viewModel.streamingBuffer) { _, _ in
                     proxy.scrollTo("bottom", anchor: .bottom)
                 }
             }

--- a/jarvis-swift/Jarvis/HUDView.swift
+++ b/jarvis-swift/Jarvis/HUDView.swift
@@ -105,8 +105,10 @@ struct HUDView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 12) {
-                        ForEach(viewModel.turns) { turn in
-                            TurnRowView(turn: turn)
+                        ForEach(Array(viewModel.turns.enumerated()), id: \.element.id) { idx, turn in
+                            let isLast = idx == viewModel.turns.count - 1
+                            let streaming = isLast && turn.response == nil ? viewModel.streamingBuffer : ""
+                            TurnRowView(turn: turn, streamingText: streaming)
                         }
                         // Invisible anchor for auto-scroll
                         Color.clear.frame(height: 1).id("bottom")
@@ -128,6 +130,9 @@ struct HUDView: View {
                     // Suppress auto-scroll during approval so buttons stay visible
                     if case .approval = viewModel.state { return }
                     withAnimation { proxy.scrollTo("bottom", anchor: .bottom) }
+                }
+                .onChange(of: viewModel.streamingBuffer) { _ in
+                    proxy.scrollTo("bottom", anchor: .bottom)
                 }
             }
             .onPreferenceChange(ThreadHeightKey.self) { height in
@@ -303,6 +308,7 @@ struct HUDView: View {
 
 private struct TurnRowView: View {
     let turn: ConversationTurn
+    var streamingText: String = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
@@ -330,9 +336,10 @@ private struct TurnRowView: View {
                 .padding(.leading, 16)
             }
 
-            // Response (only when complete)
-            if let response = turn.response {
-                Text(response)
+            // Response: final text when done, streaming text while composing
+            let displayText = turn.response ?? (streamingText.isEmpty ? nil : streamingText)
+            if let text = displayText {
+                Text(text)
                     .font(.system(size: 12, design: .monospaced))
                     .foregroundStyle(Color(red: 0.47, green: 0.8, blue: 0.47))
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/jarvis-swift/Jarvis/HUDViewModel.swift
+++ b/jarvis-swift/Jarvis/HUDViewModel.swift
@@ -32,6 +32,9 @@ class HUDViewModel: ObservableObject {
     /// Accumulates streaming tokens for live display. Cleared when the turn finalizes.
     @Published var streamingBuffer: String = ""
 
+    /// Incoming token fragments queued by the network layer; drained at display rate by AudioController timer.
+    private(set) var tokenQueue: String = ""
+
     /// Start time of the current session (first command's timestamp). Used for save filename.
     private(set) var sessionStart: Date = Date()
 
@@ -63,13 +66,24 @@ class HUDViewModel: ObservableObject {
         turns[turns.count - 1].response = response
     }
 
-    /// Append a streaming token to the live buffer.
+    /// Queue an incoming token fragment. Does NOT update streamingBuffer — the display timer does that.
     func appendToken(_ token: String) {
-        streamingBuffer += token
+        tokenQueue += token
     }
 
-    /// Clear the streaming buffer (called when complete event arrives).
+    /// Drain up to `chars` characters from the queue into streamingBuffer. Returns true if queue still has data.
+    @discardableResult
+    func drainTokenQueue(chars: Int = 8) -> Bool {
+        guard !tokenQueue.isEmpty else { return false }
+        let slice = String(tokenQueue.prefix(chars))
+        tokenQueue = String(tokenQueue.dropFirst(chars))
+        streamingBuffer += slice
+        return !tokenQueue.isEmpty
+    }
+
+    /// Clear the streaming buffer and pending queue (called on complete/clear events).
     func clearStreamingBuffer() {
+        tokenQueue = ""
         streamingBuffer = ""
     }
 


### PR DESCRIPTION
## Summary
- **Config cleanup**: removed `step_budgets` and `max_total_steps`; raised both `max_steps_claude` and `max_steps_ollama` defaults from 10 → 15
- **Wrap-up nudge**: both Claude and Ollama agents inject a nudge at `max_steps - 2` asking the model to finalize with what it has, avoiding abrupt hard-limit cut-offs with no output
- **Richer history**: `_append_turn` in router.py stores compressed tool traces (`tool(input) → result`) instead of just display text, giving future turns and the classifier real context about what happened
- **Automatic compaction**: `_compact()` calls Haiku to summarize `_history` when session exceeds ~5K tokens; `_pending_compaction_notice` flag emits a `{"type": "compacted"}` SSE event at the start of the next command
- **Classifier context**: `_classify` now receives the last 2 history turns (4 messages) so "yes please" / follow-up commands classify correctly
- **Swift**: new `case "compacted"` in `handleSSEEvent` shows a brief notice then hides HUD

## Test plan
- [ ] `cd jarvis-core && source .venv/bin/activate && pytest` — 435 passing
- [ ] Swift builds clean (`xcodebuild` BUILD SUCCEEDED)
- [ ] Send multi-turn commands in the live app and verify context carries across turns
- [ ] Verify compaction notice appears in HUD after a long session

🤖 Generated with [Claude Code](https://claude.com/claude-code)