### PR TITLE
docs: update README and CLAUDE.md to reflect Phase E state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,14 @@
 
 ## Project Overview
 
-Jarvis is a local-first AI operating layer for macOS. Activated via hotkey (⌃Space) or wake word ("Hey Jarvis"), it takes voice commands and executes them: file operations, shell commands, web search, code execution, app control, developer workflows. A floating HUD shows responses; voice narrates summaries.
+Jarvis is a local-first AI operating layer for macOS. Activated via hotkey (⌃⌥) or text input, it takes voice and text commands and executes them: file operations, shell commands, web search, code execution, app control, developer workflows. A floating HUD shows responses; voice narrates summaries.
 
-Uses a hybrid AI engine — Ollama classifies intent before execution, Claude Haiku handles most tasks (~1-2s), Claude Sonnet handles complex reasoning, with two-way delegation between Claude and Ollama.
+Primary executor is a local Qwen3.6 model served via Ollama/MLX. Claude Haiku handles tasks that need cloud reasoning, Sonnet handles complex analysis. A custom fine-tuned classifier routes commands before execution.
 
 ## Before Starting Any Work
 
 1. Run `git log --oneline -10` to see recent changes
-2. Run `cd jarvis-core && source .venv/bin/activate && pytest` to verify tests pass
+2. Run `cd jarvis-core && source .venv/bin/activate && pytest` to verify tests pass (440+ tests)
 3. Read relevant source files before modifying them
 4. Write tests before implementation (TDD)
 
@@ -17,7 +17,7 @@ Uses a hybrid AI engine — Ollama classifies intent before execution, Claude Ha
 
 Two-process system:
 
-- **Swift app** (`jarvis-swift/`) — menu bar icon, floating HUD overlay, global hotkey (⌃Space), always-on wake word, STT via SFSpeechRecognizer, TTS via macOS `say`
+- **Swift app** (`jarvis-swift/`) — menu bar icon, floating HUD overlay, global hotkey (⌃⌥), STT via SFSpeechRecognizer, TTS via AVSpeechSynthesizer, 15fps streaming display timer
 - **Python core** (`jarvis-core/`) — FastAPI server on localhost:8765, command pipeline, hybrid AI routing, tools, guardrails
 
 They communicate over local HTTP. Swift launches and monitors the Python process.
@@ -25,57 +25,70 @@ They communicate over local HTTP. Swift launches and monitors the Python process
 ### Python Core Internal Flow
 
 ```
-POST /command → CommandPipeline → Router (pre-flight Ollama classifier)
+POST /command → CommandPipeline → Router (pre-flight MLX classifier)
                       ↓                    ↓
-               ProjectMemory       haiku_first routing:
-                                   - non-complex → Agent(Haiku)
-                                   - complex_reasoning → Agent(Sonnet)
+               ProjectMemory       local_first routing:
+                                   - all intents → OllamaAgent (Qwen3.6)
+                                   - EscalateToCloud → Agent(Haiku/Sonnet)
                                          ↕ delegate_to_local
-                                   OllamaAgent (sub-tasks only)
+                                   OllamaAgent (sub-tasks)
 ```
 
 - **CommandPipeline** — `JarvisCommand` lifecycle, single-command lock, cancel/abort
-- **Router** — pre-flight Ollama classifier decides routing before any execution
-- **Agent(Haiku)** — primary executor for most tasks; fast, reliable (~1-2s)
-- **Agent(Sonnet)** — complex reasoning (web search, deep analysis); escalated by router
-- **OllamaAgent** — handles sub-tasks delegated from Claude via `delegate_to_local()`
+- **Router** — pre-flight MLX classifier decides routing; manages conversational history + compaction
+- **OllamaAgent** — primary executor (local Qwen3.6); streams finalize() answers as SSE tokens; raises `EscalateToCloud` when it can't handle a task
+- **Agent(Haiku)** — cloud fallback for escalated tasks
+- **Agent(Sonnet)** — complex reasoning (web search, deep analysis)
 - **ProjectMemory** — per-project build/test commands at `~/.jarvis/projects/<hash>/memory.json`
+
+### Conversational Session (Phase E)
+- Router holds `_history` (compressed turns) across commands in a session
+- Auto-compaction via Haiku when history exceeds ~5K tokens; deferred to next command start so it doesn't block current SSE response
+- Classifier receives last 2 history turns for context on follow-ups
+- `reset_conversation()` clears history and resets compaction state
+
+### Streaming HUD (Phase E)
+- OllamaAgent streams `finalize(answer=...)` argument chunks as SSE `token` events in real-time using an escape-aware JSON string decoder
+- Swift queues tokens in `HUDViewModel.tokenQueue`; a 15fps `Timer` drains 20 chars/tick into `streamingBuffer`
+- `TurnRowView` renders `streamingBuffer` live on the active turn; transitions to `turn.response` on completion
+- `pendingCompleteEvent` defers SSE "complete" finalization until the queue is drained; cleared on error
 
 ## Tech Stack
 
-| Layer          | Technology                                                   |
-| -------------- | ------------------------------------------------------------ |
-| macOS UI       | Swift / SwiftUI                                              |
-| STT            | Apple SFSpeechRecognizer                                     |
-| TTS            | macOS `say` command                                          |
-| Local AI       | Ollama (`llama3.1:8b` default, configurable)                 |
-| Cloud AI       | Claude Haiku (primary) + Sonnet (complex) via Anthropic SDK  |
-| Python server  | FastAPI + uvicorn                                            |
-| HTTP client    | httpx (Ollama calls)                                         |
-| Web search     | Brave Search API (or DuckDuckGo fallback)                    |
-| IPC            | Local HTTP (localhost:8765)                                  |
-| Config         | `~/.jarvis/config.json`                                      |
-| Logs           | `~/.jarvis/logs/` (errors, commands, analytics, guardrails)  |
-| Project memory | `~/.jarvis/projects/<md5(cwd)>/memory.json`                  |
+| Layer          | Technology                                                         |
+| -------------- | ------------------------------------------------------------------ |
+| macOS UI       | Swift / SwiftUI                                                    |
+| STT            | Apple SFSpeechRecognizer (en-US, contextual vocabulary biasing)    |
+| TTS            | AVSpeechSynthesizer (Daniel premium en-GB voice)                   |
+| Local AI       | Qwen3.6-35B-A3B via Ollama + MLX Rapid (3.4x speedup)             |
+| Classifier     | Custom fine-tuned Qwen on MLX (jarvis-classifier adapter, port 8090)|
+| Cloud AI       | Claude Haiku (fallback) + Sonnet (complex) via Anthropic SDK       |
+| Python server  | FastAPI + uvicorn                                                   |
+| HTTP client    | httpx (Ollama/MLX calls)                                           |
+| Web search     | Brave Search API (or DuckDuckGo fallback)                          |
+| IPC            | Local HTTP (localhost:8765)                                        |
+| Config         | `~/.jarvis/config.json`                                            |
+| Logs           | `~/.jarvis/logs/` (errors, commands, analytics, guardrails)        |
+| Project memory | `~/.jarvis/projects/<md5(cwd)>/memory.json`                        |
 
 ## Key Decisions
 
-- **Haiku-first routing** — pre-flight Ollama classifier runs before execution. Non-complex → Haiku. `complex_reasoning` → Sonnet. No mid-execution escalation.
-- **Two-way delegation** — Claude can call `delegate_to_local()` to offload simple sub-tasks to Ollama.
+- **Local-first routing** — Qwen3.6 via Ollama/MLX is the primary executor. Cloud (Haiku/Sonnet) is a fallback via `EscalateToCloud`. Goal: eliminate API dependency for most commands.
+- **Fine-tuned classifier** — Custom Qwen model trained on 500+ examples classifies intent (read_only/prepare/destructive/complex_reasoning) and routes before execution.
+- **Streaming finalize** — OllamaAgent streams the `finalize()` answer content as SSE tokens using an escape-aware JSON string decoder. No tail buffer. Metrics (TTFT, tok/s) tracked for both text and finalize paths.
+- **Conversational history** — Router compresses each turn (tool calls + result) and carries it across commands. Compaction is deferred, circuit-breakered on failure.
 - **Guardrails-first** — destructive actions require explicit approval. Pre-flight classifier also gates by intent class.
-- **Response heuristic** — < 150 chars: speak + show in HUD. ≥ 150 chars or code: speak summary only, show full in HUD.
-- **Shared dispatch** — `tools/_dispatch.py` has `execute_tool()` + `format_response()` used by both agents.
-- **No Portkey/API gateway** — direct Anthropic SDK. Low volume, unique voice commands don't benefit from caching.
-- **No always-on by default** — hotkey (⌃Space) is primary trigger; always-on is opt-in toggle in menu bar.
+- **Shared dispatch** — `tools/_dispatch.py` has `execute_tool()` + `format_response()` used by all agents.
+- **No always-on by default** — hotkey (⌃⌥) is primary trigger.
 
 ## Key Files
 
 | File | Purpose |
 |---|---|
-| `jarvis-core/server.py` | FastAPI endpoints |
+| `jarvis-core/server.py` | FastAPI endpoints, SSE event pipeline, analytics logging |
 | `jarvis-core/agent.py` | Claude agent (Haiku/Sonnet) with tool-use loop |
-| `jarvis-core/ollama_agent.py` | Ollama local agent |
-| `jarvis-core/router.py` | Pre-flight classifier + haiku_first routing |
+| `jarvis-core/ollama_agent.py` | Local Ollama/MLX agent; streaming finalize; planning-text detection |
+| `jarvis-core/router.py` | Pre-flight classifier, routing, conversational history, compaction |
 | `jarvis-core/command_pipeline.py` | Command lifecycle + single-command lock |
 | `jarvis-core/guardrails.py` | Approval engine for destructive actions |
 | `jarvis-core/config.py` | Config load/save (`~/.jarvis/config.json`) |
@@ -83,13 +96,28 @@ POST /command → CommandPipeline → Router (pre-flight Ollama classifier)
 | `jarvis-core/logger.py` | Rotating logs to `~/.jarvis/logs/` |
 | `jarvis-core/tools/` | shell, web, code, macOS, file tools |
 | `jarvis-swift/Jarvis/AppDelegate.swift` | App lifecycle, Python core launch |
-| `jarvis-swift/Jarvis/AudioController.swift` | Hotkey, STT, TTS, approval prompts |
+| `jarvis-swift/Jarvis/AudioController.swift` | Hotkey, STT, TTS, SSE stream, 15fps display timer |
+| `jarvis-swift/Jarvis/HUDView.swift` | Conversation thread, streaming turn display |
+| `jarvis-swift/Jarvis/HUDViewModel.swift` | Token queue, streamingBuffer, drain logic |
+
+## Logs
+
+Always check logs to diagnose issues — don't guess:
+
+```bash
+tail -20 ~/.jarvis/logs/commands.log     # full request/response with steps
+tail -20 ~/.jarvis/logs/analytics.log    # duration, ttft_ms, tok_s per command
+tail -20 ~/.jarvis/logs/errors.log       # exceptions, classifier failures
+```
+
+Analytics fields: `duration_ms`, `agent`, `model`, `ttft_ms`, `gen_tokens`, `tok_s`
 
 ## Rules
 
 - Run all Python tests before committing: `cd jarvis-core && source .venv/bin/activate && pytest`
-- Build Swift app (⌘B) after every Swift file change to catch compile errors early
+- Build Swift app after every Swift change: `cd jarvis-swift && xcodebuild -scheme Jarvis -configuration Debug build`
 - Write tests before implementation (TDD)
 - Commit frequently with descriptive messages
 - No hardcoded secrets — all config goes through `~/.jarvis/config.json`
 - All tools return consistent dict shape: result keys + `"error": None` or `str`
+- The SourceKit "line 1:1 Internal error" diagnostic is spurious — ignore it if the build succeeds

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 > Talk to your Mac. Jarvis handles the rest.
 
-Jarvis is a local-first AI operating layer for macOS. Activate it with ⌃Space or say "Hey Jarvis" — it takes voice commands and executes them: file operations, shell commands, web search, code execution, app control, and developer workflows. A floating HUD shows responses; voice narrates summaries.
+Jarvis is a local-first AI operating layer for macOS. Activate it with ⌃⌥ or say "Hey Jarvis" — it takes voice commands and executes them: file operations, shell commands, web search, code execution, app control, and developer workflows. A floating streaming HUD shows responses building up live; voice narrates summaries.
 
-**Hybrid AI engine:** Routes simple tasks to Claude Haiku (~1-2s), complex reasoning to Claude Sonnet, with Ollama available for fully offline operation.
+**Hybrid AI engine:** A fine-tuned Qwen classifier routes intent before execution. Local Ollama models handle most tasks offline; Claude Haiku handles cloud-dependent tasks; Claude Sonnet handles deep reasoning.
 
 ---
 
@@ -16,16 +16,17 @@ _Screenshots / GIF coming soon._
 
 ## Features
 
-- **Voice-activated** — hotkey (⌃Space) or always-on wake word
-- **Floating HUD** — non-intrusive overlay, keyboard-dismissable
-- **File & shell operations** — with guardrails and approval prompts for destructive actions
+- **Voice-activated** — hotkey (⌃⌥) or always-on wake word
+- **Live streaming HUD** — responses build up character-by-character in a floating overlay; keyboard-dismissable
+- **Conversational sessions** — full multi-turn history with auto-compaction (Haiku summarises at 5K tokens)
+- **File & shell operations** — guardrails and approval prompts for destructive actions
 - **Web search** — Brave Search API or DuckDuckGo fallback
 - **Code execution** — multi-language, project-aware
 - **App control** — open apps, AppleScript, system notifications
 - **Project memory** — remembers your build/test commands per project
-- **Haiku-first routing** — fast by default, escalates to Sonnet only when needed
+- **Local-first routing** — fine-tuned Qwen classifier gates every command; Ollama handles most tasks without a cloud call
 - **Two-way delegation** — Claude can hand off sub-tasks to local Ollama
-- **Telegram integration** — send commands from your phone, receive proactive notifications, approve destructive actions remotely (optional)
+- **MCP client** — connect GitHub and other MCP servers for rich tool access
 
 ---
 
@@ -36,11 +37,21 @@ Two-process system:
 ```
 Swift App (menu bar + HUD + hotkey + STT + TTS)
         ↕ HTTP localhost:8765
-Python Core (FastAPI + Claude API + Ollama + tools)
+Python Core (FastAPI + Ollama + Claude API + tools)
 ```
 
-- **Swift app** (`jarvis-swift/`) — menu bar icon, floating HUD, global hotkey, wake word, STT via SFSpeechRecognizer, TTS via `say`
-- **Python core** (`jarvis-core/`) — FastAPI server, hybrid AI routing, tools, guardrails, project memory
+```
+POST /command → CommandPipeline → Router (fine-tuned Qwen classifier via Ollama)
+                      ↓                    ↓
+               ProjectMemory       Local Ollama agent  (most tasks)
+                                   Claude Haiku        (cloud/tool tasks)
+                                   Claude Sonnet       (complex_reasoning)
+                                         ↕ delegate_to_local
+                                   OllamaAgent (sub-tasks)
+```
+
+- **Swift app** (`jarvis-swift/`) — menu bar icon, floating streaming HUD, global hotkey ⌃⌥, wake word, STT via SFSpeechRecognizer, TTS via AVSpeechSynthesizer
+- **Python core** (`jarvis-core/`) — FastAPI server, local-first routing, tools, guardrails, conversational history with auto-compaction
 
 ---
 
@@ -48,14 +59,14 @@ Python Core (FastAPI + Claude API + Ollama + tools)
 
 | Dependency | Version |
 |---|---|
-| macOS | 13+ |
+| macOS | 26.0+ |
 | Python | 3.11+ |
 | Ollama | latest |
-| Xcode | 15+ |
+| Xcode | 16+ |
 | Node.js | 18+ (for xcodegen) |
 
-**API Keys required:**
-- Anthropic API key (for Claude Haiku / Sonnet)
+**API Keys (optional for local-only use):**
+- Anthropic API key (for Claude Haiku / Sonnet — web search and complex reasoning)
 - Brave Search API key (optional — falls back to DuckDuckGo)
 
 ---
@@ -65,7 +76,7 @@ Python Core (FastAPI + Claude API + Ollama + tools)
 ### 1. Clone
 
 ```bash
-git clone https://github.com/YOUR_USERNAME/jarvis.git
+git clone https://github.com/Matanvil/jarvis.git
 cd jarvis
 ```
 
@@ -82,7 +93,7 @@ pip install -r requirements.txt
 
 ```bash
 cp jarvis-core/config.example.json ~/.jarvis/config.json
-# Edit ~/.jarvis/config.json — add your Anthropic API key
+# Edit ~/.jarvis/config.json — add your Anthropic API key if you want cloud AI
 ```
 
 ### 4. Start the Python server
@@ -107,7 +118,7 @@ open Jarvis.xcodeproj
 
 ## Building from source
 
-**Requirements:** macOS 13+, Xcode 15+, Python 3.11+
+**Requirements:** macOS 26.0+, Xcode 16+, Python 3.11+
 
 ### Swift app
 
@@ -116,9 +127,7 @@ open Jarvis.xcodeproj
 3. Find your Team ID: click your Apple ID row in the accounts list — the Team ID column shows the 10-character ID. Paste it into `Local.xcconfig`
 4. Open `jarvis-swift/Jarvis.xcodeproj` in Xcode and build with ⌘B
 
-On first launch, macOS will prompt for notification permission — click **Allow**.
-
-> **Without `Local.xcconfig`:** The app builds and runs but notifications fall back to the deprecated `NSUserNotificationCenter`. If you denied the permission prompt, re-enable in **System Settings → Notifications → Jarvis**.
+On first launch, macOS will prompt for Accessibility and Speech Recognition permissions — both are required.
 
 ### Python core
 
@@ -131,34 +140,17 @@ pip install -r requirements.txt
 
 ---
 
-## Optional Features
+## Local-first operation
 
-### Telegram Integration
+Jarvis is designed to work without cloud AI for most tasks. The pre-flight classifier (a fine-tuned Qwen model served via Ollama) gates every command before execution:
 
-Control Jarvis remotely from your phone and receive proactive notifications when you're away from your Mac.
+| Intent class | Handler |
+|---|---|
+| `read_only`, `prepare` | Local Ollama agent |
+| `destructive` | Local Ollama agent + approval prompt |
+| `complex_reasoning` | Claude Sonnet (web search, deep analysis) |
 
-**What it enables:**
-- Send voice commands to Jarvis via Telegram while away
-- Receive notifications when long tasks complete
-- Approve or deny destructive actions remotely with `/approve` / `/deny`
-- Toggle away mode from the menu bar, via Telegram (`/away` / `/back`), or by voice
-
-**Setup:**
-
-1. Create a bot via [@BotFather](https://t.me/BotFather) on Telegram — copy the token it gives you
-2. Find your user ID by messaging [@userinfobot](https://t.me/userinfobot)
-3. Add both to `~/.jarvis/config.json`:
-
-```json
-"telegram": {
-  "bot_token": "YOUR_BOT_TOKEN",
-  "allowed_user_id": 123456789
-}
-```
-
-4. Restart Jarvis — the bot starts automatically if configured
-
-The feature is fully opt-in. If `bot_token` is empty or `allowed_user_id` is `0`, the entire subsystem is disabled with zero overhead.
+Cloud models are only invoked when the command explicitly requires live web data or the classifier routes to `complex_reasoning`.
 
 ---
 
@@ -172,6 +164,16 @@ Run tests:
 cd jarvis-core
 source .venv/bin/activate
 pytest
+```
+
+440+ tests covering the Python core, routing, agent loops, guardrails, tools, and SSE streaming.
+
+View logs:
+
+```bash
+tail -f ~/.jarvis/logs/errors.log
+tail -f ~/.jarvis/logs/commands.log
+log show --predicate 'process == "Jarvis"' --last 5m   # Swift app logs
 ```
 
 ---


### PR DESCRIPTION
## Summary

- **README**: Updated to reflect the current state of the project after Phase E
  - Hotkey changed from ⌃Space → ⌃⌥
  - Architecture section shows local-first routing diagram with Qwen classifier
  - Features list: streaming HUD, conversational sessions, MCP client, local-first routing
  - Requirements bumped to macOS 26.0+, Xcode 16+
  - Fixed clone URL (was `YOUR_USERNAME`)
  - API keys marked optional (local-only use works without them)
  - Replaced outdated Telegram section with Local-first routing table
  - Development section: 440+ test count, log commands added

- **CLAUDE.md**: Refreshed to match Phase E implementation
  - Local-first / Qwen3.6 routing (not Haiku-first)
  - MLX classifier details
  - Phase E: streaming HUD, deferred compaction, conversational history
  - TTS via AVSpeechSynthesizer (not `say`)
  - Updated test count and benchmark results

## Test plan

- [ ] README renders correctly on GitHub (no broken links, tables format OK)
- [ ] Hotkey, architecture, and requirements all match current app behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)