### PR TITLE
feat: gate destructive intent commands behind approval prompt

### DIFF
--- a/jarvis-core/router.py
+++ b/jarvis-core/router.py
@@ -190,6 +190,33 @@ class Router:
 
         return "\n".join(lines) + "\n\n" + text
 
+    def _gate_destructive(
+        self,
+        intent_class: str,
+        command_id: str | None,
+        run_fn,           # callable(step_callback) -> result dict
+        meta: dict,       # passed to approval_store for resume annotation
+    ) -> dict | None:
+        """If intent_class is 'destructive' and no command_id approval is already
+        registered, pause execution and return an approval_required dict.
+        Returns None when the command should proceed without gating (non-destructive
+        or no command_id to resume with)."""
+        if intent_class != "destructive" or command_id is None:
+            return None
+        import approval_store
+        approval_store.register(command_id, run_fn, meta)
+        return {
+            "speak": None,
+            "display": None,
+            "steps": [],
+            "approval_required": {
+                "tool": "destructive_command",
+                "description": "This command was classified as destructive. Approve to continue.",
+                "tool_use_id": command_id,
+                "category": "destructive_command",
+            },
+        }
+
     def resume(self, command_id: str, step_callback=None) -> dict | None:
         """Continue a run paused for approval. Returns the annotated final result,
         or None if there is no paused run for this command_id (caller falls back to
@@ -241,6 +268,20 @@ class Router:
                           self._config.get("models", {}).get("haiku", "claude-haiku-4-5-20251001"))
 
             user_text = self._build_user_prefix(text, cwd, memory_context, intent_class, source)
+
+            gate = self._gate_destructive(
+                intent_class, command_id,
+                lambda sc, _a=agent, _ut=user_text, _mn=model_name: (
+                    _a.run(user_text=_ut, cwd=cwd, history=self._history, source=source,
+                           step_callback=sc, command_id=command_id,
+                           system_prompt=self._get_system_prompt(cwd))
+                ),
+                {"user_text": text, "agent": "claude", "model": model_name,
+                 "intent_class": intent_class, "escalation_reason": classification.get("reason")},
+            )
+            if gate is not None:
+                return gate
+
             result = agent.run(user_text=user_text, cwd=cwd, history=self._history, source=source,
                                step_callback=step_callback, command_id=command_id,
                                system_prompt=self._get_system_prompt(cwd))
@@ -273,6 +314,20 @@ class Router:
                 return self._annotate(result, agent="claude", model=model_name,
                                       escalated=False, escalation_reason=classification.get("reason"),
                                       intent_class=intent_class, start=start)
+
+            gate = self._gate_destructive(
+                intent_class, command_id,
+                lambda sc, _ut=user_text: self._ollama.run(
+                    user_text=_ut, cwd=cwd, history=self._history,
+                    step_callback=sc, intent_class=intent_class, command_id=command_id,
+                    system_prompt=self._get_local_system_prompt(cwd),
+                ),
+                {"user_text": text, "agent": "ollama",
+                 "model": self._config.get("ollama", {}).get("executor_model") or self._ollama_model,
+                 "intent_class": intent_class},
+            )
+            if gate is not None:
+                return gate
 
             # Non-complex: use local OllamaAgent; escalate to Sonnet on failure
             try:
@@ -324,6 +379,19 @@ class Router:
         intent_class = classification.get("intent_class", "read_only")
         can_handle_locally = classification.get("can_handle_locally", True)
         user_text = self._build_user_prefix(text, cwd, memory_context, intent_class, source)
+
+        gate = self._gate_destructive(
+            intent_class, command_id,
+            lambda sc, _ut=user_text: self._ollama.run(
+                user_text=_ut, cwd=cwd, history=self._history,
+                step_callback=sc, intent_class=intent_class, command_id=command_id,
+                system_prompt=self._get_local_system_prompt(cwd),
+            ),
+            {"user_text": text, "agent": "ollama", "model": self._ollama_model,
+             "intent_class": intent_class},
+        )
+        if gate is not None:
+            return gate
 
         escalation_reason = None
         if mode == "ollama_only" or can_handle_locally:

--- a/jarvis-core/tests/test_router.py
+++ b/jarvis-core/tests/test_router.py
@@ -638,3 +638,85 @@ def test_git_context_skipped_for_read_only_intent(prefix_router):
     with patch("router.get_git_context", return_value=ctx) as mock_gc:
         prefix_router.process("what time is it", cwd="/repo")
     mock_gc.assert_not_called()
+
+
+# ── destructive intent approval gate ─────────────────────────────────────────
+
+def test_destructive_intent_returns_approval_required(haiku_router, mock_haiku_agent):
+    """A destructive command must pause and return approval_required before running."""
+    haiku_router._classify = MagicMock(return_value={
+        "can_handle_locally": True, "intent_class": "destructive", "reason": "deletes files"
+    })
+    result = haiku_router.process("delete all temp files", command_id="cmd-1")
+    assert "approval_required" in result
+    assert result["approval_required"]["category"] == "destructive_command"
+    mock_haiku_agent.run.assert_not_called()
+
+
+def test_destructive_intent_registers_resume_in_approval_store(haiku_router):
+    """Paused destructive command must be registered so resume() can continue it."""
+    import approval_store
+    approval_store.clear()
+    haiku_router._classify = MagicMock(return_value={
+        "can_handle_locally": True, "intent_class": "destructive", "reason": "rm -rf"
+    })
+    haiku_router.process("wipe the build directory", command_id="cmd-2")
+    assert approval_store.has("cmd-2")
+
+
+def test_destructive_intent_resume_runs_agent(haiku_router, mock_haiku_agent):
+    """After approval, resume() must run the agent and return an annotated result."""
+    import approval_store
+    approval_store.clear()
+    mock_haiku_agent.run.return_value = {"speak": "Done.", "display": "Done.", "steps": []}
+    haiku_router._classify = MagicMock(return_value={
+        "can_handle_locally": True, "intent_class": "destructive", "reason": "deletes"
+    })
+    haiku_router.process("remove old logs", command_id="cmd-3")
+    assert approval_store.has("cmd-3")
+
+    result = haiku_router.resume("cmd-3")
+    assert result["speak"] == "Done."
+    assert result["_intent_class"] == "destructive"
+    mock_haiku_agent.run.assert_called_once()
+    assert not approval_store.has("cmd-3")
+
+
+def test_non_destructive_intent_runs_without_gate(haiku_router, mock_haiku_agent):
+    """Non-destructive commands must not be gated — agent runs immediately."""
+    import approval_store
+    approval_store.clear()
+    haiku_router._classify = MagicMock(return_value={
+        "can_handle_locally": True, "intent_class": "prepare", "reason": "read-ish"
+    })
+    result = haiku_router.process("list all files", command_id="cmd-4")
+    assert "approval_required" not in result
+    mock_haiku_agent.run.assert_called_once()
+    assert not approval_store.has("cmd-4")
+
+
+def test_destructive_without_command_id_runs_immediately(haiku_router, mock_haiku_agent):
+    """Without a command_id there's no way to resume, so run immediately (no gate)."""
+    haiku_router._classify = MagicMock(return_value={
+        "can_handle_locally": True, "intent_class": "destructive", "reason": "deletes"
+    })
+    result = haiku_router.process("delete build artifacts")  # no command_id
+    assert "approval_required" not in result
+    mock_haiku_agent.run.assert_called_once()
+
+
+def test_destructive_gate_in_ollama_first_mode(config, mock_ollama_agent):
+    """ollama_first routing must also gate destructive commands."""
+    import approval_store
+    approval_store.clear()
+    config["ollama"]["routing_mode"] = "ollama_first"
+    guardrails = Guardrails(config)
+    r = Router(config=config, guardrails=guardrails)
+    r._ollama = mock_ollama_agent
+    r._classify = MagicMock(return_value={
+        "can_handle_locally": True, "intent_class": "destructive", "reason": "rm"
+    })
+    result = r.process("clean the repo", command_id="cmd-5")
+    assert "approval_required" in result
+    mock_ollama_agent.run.assert_not_called()
+    assert approval_store.has("cmd-5")

--- a/jarvis-core/tools/_dispatch.py
+++ b/jarvis-core/tools/_dispatch.py
@@ -257,12 +257,14 @@ def format_response(text: str, tool_calls_made: list) -> dict:
     If the model included a VOICE: line, use it as the spoken summary and
     strip it from the displayed text. Falls back to first-sentence heuristic.
     """
-    # Extract VOICE: tag if present (model-generated TTS summary)
+    # Extract VOICE: tag if present (model-generated TTS summary); case-insensitive
+    # so "VOICe:", "voice:", etc. are all caught.
     voice_line = None
     display_lines = []
     for line in text.splitlines():
         stripped = line.strip()
-        if stripped.startswith("VOICE:"):
+        upper = stripped.upper()
+        if upper.startswith("VOICE:"):
             voice_line = stripped[len("VOICE:"):].strip()
         else:
             display_lines.append(line)

--- a/jarvis-swift/Jarvis/AppDelegate.swift
+++ b/jarvis-swift/Jarvis/AppDelegate.swift
@@ -567,7 +567,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             },
             onSettings: {
                 SettingsWindowController.shared.open()
-            }
+            },
+            onApprove: { [weak self] in self?.handleApprove() },
+            onDeny:    { [weak self] in self?.handleDeny() }
         )
     }
 

--- a/jarvis-swift/Jarvis/FullDesktopView.swift
+++ b/jarvis-swift/Jarvis/FullDesktopView.swift
@@ -800,6 +800,8 @@ struct DesktopInputBar: View {
     @ObservedObject var viewModel: HUDViewModel
     var onTextCommand: (String) -> Void
     var onVoice: () -> Void
+    var onApprove: () -> Void = {}
+    var onDeny: () -> Void = {}
 
     @State private var inputText = ""
     @FocusState private var focused: Bool
@@ -812,74 +814,114 @@ struct DesktopInputBar: View {
     }
 
     var body: some View {
-        VStack(spacing: 8) {
-            // Placeholder action chips — not wired, coming soon
-            HStack(spacing: 6) {
-                ForEach(actionChips, id: \.self) { chip in
-                    Text(chip)
-                        .font(.system(size: 10, design: .monospaced))
-                        .foregroundColor(textDim)
-                        .padding(.horizontal, 9)
-                        .padding(.vertical, 4)
-                        .overlay(Capsule().stroke(cardBorder, lineWidth: 1))
-                }
-                .opacity(0.4)
-                Spacer()
-            }
-
-            HStack(spacing: 8) {
-                Button(action: onVoice) {
-                    Image(systemName: "mic.circle.fill")
-                        .font(.system(size: 28))
-                        .foregroundColor(accentCyan)
-                }
-                .buttonStyle(.plain)
-
-                TextField("Ask Jarvis anything…", text: $inputText)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 13))
-                    .foregroundColor(.white)
-                    .focused($focused)
-                    .disabled(isDisabled)
-                    .onSubmit {
-                        guard !inputText.trimmingCharacters(in: .whitespaces).isEmpty else { return }
-                        onTextCommand(inputText)
-                        inputText = ""
-                    }
-                    .onChange(of: viewModel.state) { _, newState in
-                        // Re-focus after each command completes so the user can type immediately.
-                        switch newState {
-                        case .response, .approved, .denied:
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { focused = true }
-                        default: break
-                        }
-                    }
-                    .onAppear { focused = true }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(accentCyan.opacity(0.04))
-                    .overlay(RoundedRectangle(cornerRadius: 8).stroke(cardBorder, lineWidth: 1))
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-
-                Button {
-                    guard !inputText.trimmingCharacters(in: .whitespaces).isEmpty else { return }
-                    onTextCommand(inputText)
-                    inputText = ""
-                } label: {
-                    Image(systemName: "paperplane.fill")
+        Group {
+            if case .approval(let description) = viewModel.state {
+                // Approval banner — replaces normal input when waiting for user confirmation
+                HStack(spacing: 10) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.orange)
                         .font(.system(size: 14))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Approval Required")
+                            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                            .foregroundColor(.orange)
+                        Text(description)
+                            .font(.system(size: 12))
+                            .foregroundColor(.white.opacity(0.85))
+                            .lineLimit(2)
+                    }
+                    Spacer()
+                    Button("Deny", action: onDeny)
+                        .buttonStyle(.plain)
+                        .font(.system(size: 12, weight: .medium))
                         .foregroundColor(.white)
-                        .padding(10)
-                        .background(accentCyan)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                        .shadow(color: accentCyan.opacity(0.4), radius: 8)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 7)
+                        .background(Color.red.opacity(0.7))
+                        .clipShape(RoundedRectangle(cornerRadius: 7))
+                    Button("Allow", action: onApprove)
+                        .buttonStyle(.plain)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.black)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 7)
+                        .background(Color.green.opacity(0.85))
+                        .clipShape(RoundedRectangle(cornerRadius: 7))
                 }
-                .buttonStyle(.plain)
+                .padding(14)
+                .background(bgSurface)
+                .overlay(Rectangle().frame(height: 1).foregroundColor(cardBorder), alignment: .top)
+            } else {
+                VStack(spacing: 8) {
+                    // Placeholder action chips — not wired, coming soon
+                    HStack(spacing: 6) {
+                        ForEach(actionChips, id: \.self) { chip in
+                            Text(chip)
+                                .font(.system(size: 10, design: .monospaced))
+                                .foregroundColor(textDim)
+                                .padding(.horizontal, 9)
+                                .padding(.vertical, 4)
+                                .overlay(Capsule().stroke(cardBorder, lineWidth: 1))
+                        }
+                        .opacity(0.4)
+                        Spacer()
+                    }
+
+                    HStack(spacing: 8) {
+                        Button(action: onVoice) {
+                            Image(systemName: "mic.circle.fill")
+                                .font(.system(size: 28))
+                                .foregroundColor(accentCyan)
+                        }
+                        .buttonStyle(.plain)
+
+                        TextField("Ask Jarvis anything…", text: $inputText)
+                            .textFieldStyle(.plain)
+                            .font(.system(size: 13))
+                            .foregroundColor(.white)
+                            .focused($focused)
+                            .disabled(isDisabled)
+                            .onSubmit {
+                                guard !inputText.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+                                onTextCommand(inputText)
+                                inputText = ""
+                            }
+                            .onChange(of: viewModel.state) { _, newState in
+                                // Re-focus after each command completes so the user can type immediately.
+                                switch newState {
+                                case .response, .approved, .denied:
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { focused = true }
+                                default: break
+                                }
+                            }
+                            .onAppear { focused = true }
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(accentCyan.opacity(0.04))
+                            .overlay(RoundedRectangle(cornerRadius: 8).stroke(cardBorder, lineWidth: 1))
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                        Button {
+                            guard !inputText.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+                            onTextCommand(inputText)
+                            inputText = ""
+                        } label: {
+                            Image(systemName: "paperplane.fill")
+                                .font(.system(size: 14))
+                                .foregroundColor(.white)
+                                .padding(10)
+                                .background(accentCyan)
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                                .shadow(color: accentCyan.opacity(0.4), radius: 8)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(14)
+                .background(bgSurface)
+                .overlay(Rectangle().frame(height: 1).foregroundColor(cardBorder), alignment: .top)
             }
         }
-        .padding(14)
-        .background(bgSurface)
-        .overlay(Rectangle().frame(height: 1).foregroundColor(cardBorder), alignment: .top)
     }
 }
 
@@ -925,6 +967,8 @@ struct CenterColumn: View {
     var onCollapse: () -> Void
     var onTextCommand: (String) -> Void
     var onVoice: () -> Void
+    var onApprove: () -> Void = {}
+    var onDeny: () -> Void = {}
 
     private var hasConversation: Bool { !viewModel.turns.isEmpty }
 
@@ -952,7 +996,9 @@ struct CenterColumn: View {
             DesktopInputBar(
                 viewModel: viewModel,
                 onTextCommand: onTextCommand,
-                onVoice: onVoice
+                onVoice: onVoice,
+                onApprove: onApprove,
+                onDeny: onDeny
             )
         }
         .background(bgPrimary)
@@ -1026,6 +1072,8 @@ struct FullDesktopView: View {
     var onTextCommand: (String) -> Void = { _ in }
     var onVoice: () -> Void = {}
     var onSettings: () -> Void = {}
+    var onApprove: () -> Void = {}
+    var onDeny: () -> Void = {}
 
     var body: some View {
         VStack(spacing: 0) {
@@ -1045,7 +1093,9 @@ struct FullDesktopView: View {
                     fullViewModel: fullViewModel,
                     onCollapse: onCollapse,
                     onTextCommand: onTextCommand,
-                    onVoice: onVoice
+                    onVoice: onVoice,
+                    onApprove: onApprove,
+                    onDeny: onDeny
                 )
 
                 Divider().background(cardBorder)

--- a/jarvis-swift/Jarvis/FullDesktopWindow.swift
+++ b/jarvis-swift/Jarvis/FullDesktopWindow.swift
@@ -10,7 +10,9 @@ final class FullDesktopWindow: NSWindow {
         onCollapse: @escaping () -> Void,
         onTextCommand: @escaping (String) -> Void,
         onVoice: @escaping () -> Void,
-        onSettings: @escaping () -> Void
+        onSettings: @escaping () -> Void,
+        onApprove: @escaping () -> Void = {},
+        onDeny: @escaping () -> Void = {}
     ) {
         let screen = NSScreen.main?.visibleFrame ?? CGRect(x: 0, y: 0, width: 1440, height: 900)
         let width  = min(screen.width * 0.9, 1440)
@@ -40,7 +42,9 @@ final class FullDesktopWindow: NSWindow {
             onCollapse: onCollapse,
             onTextCommand: onTextCommand,
             onVoice: onVoice,
-            onSettings: onSettings
+            onSettings: onSettings,
+            onApprove: onApprove,
+            onDeny: onDeny
         )
         contentView = NSHostingView(rootView: rootView)
     }


### PR DESCRIPTION
## Summary

- Pre-flight classifier already labels commands as `destructive`, but the approval gate was purely tool-based — MCP tool calls like `merge_pull_request` ran completely unchecked even when classified destructive (this is how Jarvis merged a PR without asking)
- `_gate_destructive()` in `Router` pauses execution **before the agent runs**, registers a resume lambda in `approval_store` (same mechanism as tool-level guardrails), and returns `approval_required` to the caller
- On approval, `router.resume()` picks up and runs the agent normally with full annotation
- Applied to all routing modes: `haiku_first`, `local_first`, `ollama_first`, `ollama_only`
- Commands without a `command_id` bypass the gate (no way to resume — runs immediately)

## What broke this before

When Jarvis was asked to merge a PR, the classifier correctly flagged it as `destructive` — but `Guardrails` only checks tool categories, and `mcp__github__merge_pull_request` has no category. The `destructive` intent class was only used for routing decisions, never for access control.

## Test plan
- [ ] Ask Jarvis to do something destructive (delete files, merge a PR, run `rm -rf`) — should get an approval prompt before any tools run
- [ ] Approve → command executes normally
- [ ] Deny → command is discarded
- [ ] Non-destructive commands (`read_only`, `prepare`, `complex_reasoning`) run immediately without prompt
- [ ] 472 Python tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)