### PR TITLE
feat: approval UI, VOICE: fix, ESC abort

### DIFF
--- a/jarvis-swift/Jarvis/AppDelegate.swift
+++ b/jarvis-swift/Jarvis/AppDelegate.swift
@@ -38,6 +38,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     private var audioController: AudioController!
     private var cancellables = Set<AnyCancellable>()
     private var alertListenerTask: Task<Void, Never>?
+    private var escKeyMonitor: Any?
 
     // MARK: - Lifecycle
 
@@ -110,6 +111,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         startAlertListener()
         installToApplicationsIfNeeded()
         checkFullDiskAccess()
+        installEscKeyMonitor()
     }
 
     // MARK: - Alert Listener
@@ -579,5 +581,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
     private func handleDeny() {
         Task { @MainActor in audioController.submitApproval(approved: false) }
+    }
+
+    private func installEscKeyMonitor() {
+        escKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            // ESC key code is 53
+            guard event.keyCode == 53, let self else { return event }
+            Task { @MainActor in self.audioController.abortCurrentCommand() }
+            return nil  // consume the event
+        }
     }
 }

--- a/jarvis-swift/Jarvis/AudioController.swift
+++ b/jarvis-swift/Jarvis/AudioController.swift
@@ -365,6 +365,26 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
         }
     }
 
+    // MARK: - Abort
+
+    func abortCurrentCommand() {
+        switch viewModel.state {
+        case .listening, .thinking, .executing, .approval:
+            break
+        default:
+            return
+        }
+        viewModel.finalizeTurn(response: "Aborted.")
+        showHUD(.denied)
+        stopStreamTimer()
+        viewModel.clearStreamingBuffer()
+        Task { await client.abort() }
+        Task {
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            await MainActor.run { self.hideHUD() }
+        }
+    }
+
     // MARK: - Config
 
     func refreshConfig() async {

--- a/jarvis-swift/Jarvis/JarvisClient.swift
+++ b/jarvis-swift/Jarvis/JarvisClient.swift
@@ -153,6 +153,14 @@ final class JarvisClient {
         }
     }
 
+    /// POSTs to /commands/abort — no auth token required (exempt path).
+    func abort() async {
+        guard let url = URL(string: "\(baseURL)/commands/abort") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        _ = try? await quickSession.data(for: request)
+    }
+
     /// Returns true (approved), false (denied), or nil (unclear — caller should stay in approval state)
     func classifyApproval(text: String) async throws -> Bool? {
         var request = URLRequest(url: URL(string: "\(baseURL)/approve/classify")!)


### PR DESCRIPTION
## Summary
- Approval banner in Full Desktop when a destructive command is gated (orange warning, Deny/Allow buttons)
- Case-insensitive VOICE: stripping — mixed-case variants like `VOICe:` no longer leak into the speak field
- ESC key aborts any running command: fires `/commands/abort`, finalizes turn with "Aborted.", clears streaming buffer, hides HUD after 1.5s

## Test plan
- [ ] Trigger a destructive command in Full Desktop — approval banner appears with Deny/Allow
- [ ] Deny → turn shows "Denied.", HUD hides
- [ ] Allow → command executes
- [ ] Press ESC during a running command (thinking/executing) → turn shows "Aborted.", HUD hides
- [ ] Press ESC when idle → no effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)