### PR TITLE
fix: exempt /commands/abort from auth token check

### DIFF
--- a/jarvis-core/server.py
+++ b/jarvis-core/server.py
@@ -214,7 +214,7 @@ app = FastAPI(lifespan=lifespan)
 # POST /command and get arbitrary shell execution. Enforced only when the token is
 # set — a manually-run dev server (or the test client) stays open.
 _AUTH_TOKEN = os.environ.get("JARVIS_AUTH_TOKEN", "")
-_AUTH_EXEMPT_PATHS = {"/health"}
+_AUTH_EXEMPT_PATHS = {"/health", "/commands/abort"}
 
 
 @app.middleware("http")

--- a/jarvis-swift/Jarvis/AppDelegate.swift
+++ b/jarvis-swift/Jarvis/AppDelegate.swift
@@ -38,6 +38,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     private var audioController: AudioController!
     private var cancellables = Set<AnyCancellable>()
     private var alertListenerTask: Task<Void, Never>?
+    private var escKeyMonitor: Any?
 
     // MARK: - Lifecycle
 
@@ -110,6 +111,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         startAlertListener()
         installToApplicationsIfNeeded()
         checkFullDiskAccess()
+        installEscKeyMonitor()
     }
 
     // MARK: - Alert Listener
@@ -579,5 +581,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
     private func handleDeny() {
         Task { @MainActor in audioController.submitApproval(approved: false) }
+    }
+
+    private func installEscKeyMonitor() {
+        escKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            // ESC key code is 53
+            guard event.keyCode == 53, let self else { return event }
+            Task { @MainActor in self.audioController.abortCurrentCommand() }
+            return nil  // consume the event
+        }
     }
 }

--- a/jarvis-swift/Jarvis/AudioController.swift
+++ b/jarvis-swift/Jarvis/AudioController.swift
@@ -365,6 +365,26 @@ final class AudioController: NSObject, SFSpeechRecognizerDelegate {
         }
     }
 
+    // MARK: - Abort
+
+    func abortCurrentCommand() {
+        switch viewModel.state {
+        case .listening, .thinking, .executing, .approval:
+            break
+        default:
+            return
+        }
+        viewModel.finalizeTurn(response: "Aborted.")
+        showHUD(.denied)
+        stopStreamTimer()
+        viewModel.clearStreamingBuffer()
+        Task { await client.abort() }
+        Task {
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            await MainActor.run { self.hideHUD() }
+        }
+    }
+
     // MARK: - Config
 
     func refreshConfig() async {

--- a/jarvis-swift/Jarvis/JarvisClient.swift
+++ b/jarvis-swift/Jarvis/JarvisClient.swift
@@ -153,6 +153,14 @@ final class JarvisClient {
         }
     }
 
+    /// POSTs to /commands/abort — no auth token required (exempt path).
+    func abort() async {
+        guard let url = URL(string: "\(baseURL)/commands/abort") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        _ = try? await quickSession.data(for: request)
+    }
+
     /// Returns true (approved), false (denied), or nil (unclear — caller should stay in approval state)
     func classifyApproval(text: String) async throws -> Bool? {
         var request = URLRequest(url: URL(string: "\(baseURL)/approve/classify")!)


### PR DESCRIPTION
## Summary
- `/commands/abort` added to `_AUTH_EXEMPT_PATHS` so the ESC key abort can reach the server even when it is stuck holding the command lock (and the normal auth flow can't complete).

## Test plan
- [ ] Start a long-running command, press ESC — abort reaches server without auth error

🤖 Generated with [Claude Code](https://claude.com/claude-code)