### PR TITLE
refactor: rename ollama→local; consolidate routing modes to local/cloud/automatic

### DIFF
--- a/jarvis-core/.gitignore
+++ b/jarvis-core/.gitignore
@@ -4,3 +4,6 @@ benchmark_*.json
 
 # Generated/external source dirs
 src/
+
+# Local dev config — may contain live API keys, never commit
+config.dev.json

--- a/jarvis-core/agent.py
+++ b/jarvis-core/agent.py
@@ -448,7 +448,7 @@ class _ClaudeLoopState:
     system_prompt: str
     cwd: str | None
     source: str
-    ollama_available: bool
+    local_available: bool
     command_id: str | None
     user_text: str
     # Resume point — set only while paused mid-turn.
@@ -501,7 +501,7 @@ class Agent:
         return prompt
 
     def run(self, user_text: str, cwd: str | None = None, memory_context: str = "",
-            history: list | None = None, ollama_available: bool = True,
+            history: list | None = None, local_available: bool = True,
             source: str = "", step_callback=None, command_id: str | None = None,
             system_prompt: str | None = None) -> dict:
         """Run the agent loop. cwd sets the active project directory for all tool calls.
@@ -517,7 +517,7 @@ class Agent:
             system_prompt=system_prompt if system_prompt is not None else self._build_system_prompt(cwd, memory_context, source),
             cwd=cwd,
             source=source,
-            ollama_available=ollama_available,
+            local_available=local_available,
             command_id=command_id,
             user_text=user_text,
         )
@@ -554,7 +554,7 @@ class Agent:
             # Omit notify for scheduled tasks — the scheduler fires the notification itself.
             available_tools = [
                 t for t in self._build_tool_list()
-                if (t["name"] != "delegate_to_local" or state.ollama_available)
+                if (t["name"] != "delegate_to_local" or state.local_available)
                 and (t["name"] != "notify" or state.source != "scheduled")
             ]
 

--- a/jarvis-core/config.py
+++ b/jarvis-core/config.py
@@ -25,10 +25,10 @@ DEFAULTS = {
         "modify_system": "require_approval",
         "run_code_with_effects": "auto_allow",
     },
-    "ollama": {
+    "local": {
         "host": "http://localhost:11434",
         "model": "qwen3.6:35b-a3b",
-        "routing_mode": "local_first",   # local_first | haiku_first | ollama_first | claude_only | ollama_only
+        "routing_mode": "automatic",   # automatic | local | cloud
         "timeout_seconds": 300,
         "executor_host": "http://127.0.0.1:8093",
         "executor_model": "mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -40,7 +40,7 @@ DEFAULTS = {
     },
     "reasoning": {
         "max_steps_claude": 15,
-        "max_steps_ollama": 15,
+        "max_steps_local": 15,
         "stall_detection": True,
     },
     "narration": {
@@ -58,6 +58,29 @@ DEFAULTS = {
     "local_model": "",
     "mcp_servers": [],
 }
+
+
+def _migrate(data: dict) -> dict:
+    """Migrate legacy config keys/values in-place."""
+    # Move "ollama" → "local"
+    if "ollama" in data and "local" not in data:
+        data["local"] = data.pop("ollama")
+    # Migrate routing mode values
+    _MODE_MAP = {
+        "local_first": "automatic",
+        "ollama_only": "local",
+        "claude_only": "cloud",
+        "ollama_first": "automatic",
+        "haiku_first": "automatic",
+    }
+    local = data.get("local", {})
+    if local.get("routing_mode") in _MODE_MAP:
+        local["routing_mode"] = _MODE_MAP[local["routing_mode"]]
+    # Rename max_steps_ollama → max_steps_local
+    r = data.get("reasoning", {})
+    if "max_steps_ollama" in r and "max_steps_local" not in r:
+        r["max_steps_local"] = r.pop("max_steps_ollama")
+    return data
 
 
 def _deep_merge(base: dict, override: dict) -> dict:
@@ -79,9 +102,10 @@ def load() -> dict:
     else:
         with open(CONFIG_PATH) as f:
             data = json.load(f)
+        data = _migrate(data)
         cfg = {**DEFAULTS, **data}
         cfg["guardrails"] = {**DEFAULTS["guardrails"], **data.get("guardrails", {})}
-        cfg["ollama"] = {**DEFAULTS["ollama"], **data.get("ollama", {})}
+        cfg["local"] = {**DEFAULTS["local"], **data.get("local", {})}
         cfg["reasoning"] = {**DEFAULTS["reasoning"], **data.get("reasoning", {})}
         cfg["narration"] = {**DEFAULTS["narration"], **data.get("narration", {})}
         cfg["models"] = {**DEFAULTS["models"], **data.get("models", {})}
@@ -111,8 +135,8 @@ def save(cfg: dict) -> None:
 
 def executor_backend(config: dict) -> tuple[str, str]:
     """(host, model) for the local executor model. Prefers explicit executor_* keys,
-    falls back to the base ollama host/model."""
-    o = config.get("ollama", {})
+    falls back to the base local host/model."""
+    o = config.get("local", {})
     host = o.get("executor_host") or o.get("host") or "http://localhost:11434"
     model = o.get("executor_model") or o.get("model") or "mistral:latest"
     return host, model
@@ -120,7 +144,7 @@ def executor_backend(config: dict) -> tuple[str, str]:
 
 def classifier_backend(config: dict) -> tuple[str, str]:
     """(host, model) for the intent / approval classifier."""
-    o = config.get("ollama", {})
+    o = config.get("local", {})
     host = o.get("classifier_host") or o.get("host") or "http://localhost:11434"
     model = o.get("classifier_model") or o.get("model") or "mistral:latest"
     return host, model
@@ -128,7 +152,7 @@ def classifier_backend(config: dict) -> tuple[str, str]:
 
 def embedder_backend(config: dict) -> tuple[str, str]:
     """(host, model) for embeddings (coding-agent semantic index)."""
-    o = config.get("ollama", {})
+    o = config.get("local", {})
     host = o.get("embedder_host") or o.get("host") or "http://localhost:11434"
     model = o.get("embedder_model") or "nomic-embed-text"
     return host, model

--- a/jarvis-core/config.py
+++ b/jarvis-core/config.py
@@ -3,7 +3,6 @@ import json
 from pathlib import Path
 
 CONFIG_PATH = Path.home() / ".jarvis" / "config.json"
-DEV_CONFIG_PATH = Path(__file__).parent / "config.dev.json"
 
 DEFAULTS = {
     "anthropic_api_key": "",
@@ -87,11 +86,6 @@ def load() -> dict:
         cfg["narration"] = {**DEFAULTS["narration"], **data.get("narration", {})}
         cfg["models"] = {**DEFAULTS["models"], **data.get("models", {})}
         cfg["telegram"] = {**DEFAULTS["telegram"], **data.get("telegram", {})}
-
-    if DEV_CONFIG_PATH.exists():
-        with open(DEV_CONFIG_PATH) as f:
-            dev = json.load(f)
-        cfg = _deep_merge(cfg, dev)
 
     return cfg
 

--- a/jarvis-core/local_agent.py
+++ b/jarvis-core/local_agent.py
@@ -57,7 +57,7 @@ def _is_action_trace(text: str) -> bool:
 
 
 # Appended to the base system prompt for local models that need extra guidance
-_OLLAMA_EXTRA = """
+_LOCAL_EXTRA = """
 CRITICAL RULES FOR THIS MODEL:
 - Respond ONLY in English. Never use Thai, Chinese, Arabic, or any non-English language.
 - ALWAYS use the provided tool/function calls to take action. NEVER write tool calls as JSON text in your response.
@@ -72,7 +72,7 @@ CRITICAL RULES FOR THIS MODEL:
 """
 
 
-def _clean_ollama_text(text: str) -> str:
+def _clean_local_text(text: str) -> str:
     """Strip non-English garbage common in qwen/mistral outputs."""
     # Remove embedded tool call JSON blocks the model leaked into text
     text = re.sub(r'\{["\s]*name["\s]*:[^}]+\}', '', text)
@@ -93,7 +93,7 @@ class EscalateToCloud(Exception):
         super().__init__(f"Escalate to Claude: {reason}")
 
 
-def _anthropic_to_ollama_tools(anthropic_tools: list) -> list:
+def _anthropic_to_local_tools(anthropic_tools: list) -> list:
     """Convert Anthropic tool schema format to OpenAI/Ollama format."""
     return [
         {
@@ -108,10 +108,10 @@ def _anthropic_to_ollama_tools(anthropic_tools: list) -> list:
     ]
 
 
-# Exclude delegation tools — OllamaAgent is the delegate, not the delegator.
+# Exclude delegation tools — LocalAgent is the delegate, not the delegator.
 # Routing decisions are made by the pre-flight classifier in Router, not by tool calls.
 _DELEGATION_TOOLS = {"delegate_to_claude_code", "delegate_to_local", "coding_ask", "coding_plan", "coding_review"}
-_OLLAMA_SAFE_TOOL_DEFINITIONS = [t for t in TOOL_DEFINITIONS if t["name"] not in _DELEGATION_TOOLS]
+_LOCAL_SAFE_TOOL_DEFINITIONS = [t for t in TOOL_DEFINITIONS if t["name"] not in _DELEGATION_TOOLS]
 _FINALIZE_TOOL = {
     "type": "function",
     "function": {
@@ -134,7 +134,7 @@ _FINALIZE_TOOL = {
     },
 }
 
-_OLLAMA_TOOLS = _anthropic_to_ollama_tools(_OLLAMA_SAFE_TOOL_DEFINITIONS) + [_FINALIZE_TOOL]
+_LOCAL_TOOLS = _anthropic_to_local_tools(_LOCAL_SAFE_TOOL_DEFINITIONS) + [_FINALIZE_TOOL]
 
 
 _FINALIZE_ANSWER_RE = re.compile(r'"answer"\s*:\s*"')
@@ -319,8 +319,8 @@ def _stream_call(client: "httpx.Client", url: str, payload: dict,
 
 
 @dataclass
-class _OllamaLoopState:
-    """Mutable state for one Ollama run, carried across a pause/resume so an
+class _LocalLoopState:
+    """Mutable state for one local run, carried across a pause/resume so an
     approved run continues instead of replaying from the original command."""
     messages: list
     tool_calls_made: list
@@ -345,7 +345,7 @@ class _OllamaLoopState:
     pending_dpo: dict | None = None
 
 
-class OllamaAgent:
+class LocalAgent:
     def __init__(self, config: dict, guardrails: Guardrails, mcp_manager=None):
         self._config = config
         self._guardrails = guardrails
@@ -362,11 +362,11 @@ class OllamaAgent:
         )
 
     def _build_tool_list(self) -> list[dict]:
-        """Return Ollama-format tool list with built-ins plus any MCP tools."""
-        base = list(_OLLAMA_TOOLS)
+        """Return local-format tool list with built-ins plus any MCP tools."""
+        base = list(_LOCAL_TOOLS)
         if self._mcp_manager is not None:
             mcp_schemas = self._mcp_manager.tool_schemas()
-            base = base + _anthropic_to_ollama_tools(mcp_schemas)
+            base = base + _anthropic_to_local_tools(mcp_schemas)
         return base
 
     def close(self) -> None:
@@ -390,18 +390,18 @@ class OllamaAgent:
 
     @property
     def _chat_template_kwargs(self) -> dict | None:
-        # rapid-mlx handles chat templating internally — don't inject Ollama-specific kwargs
-        if self._config.get("ollama", {}).get("executor_rapid_mlx"):
+        # rapid-mlx handles chat templating internally — don't inject local-specific kwargs
+        if self._config.get("local", {}).get("executor_rapid_mlx"):
             return None
-        return self._config.get("ollama", {}).get("executor_chat_template_kwargs")
+        return self._config.get("local", {}).get("executor_chat_template_kwargs")
 
     @property
     def _routing_mode(self) -> str:
-        return self._config.get("ollama", {}).get("routing_mode", "ollama_first")
+        return self._config.get("local", {}).get("routing_mode", "automatic")
 
     @property
     def _timeout(self) -> float:
-        return float(self._config.get("ollama", {}).get("timeout_seconds", 300))
+        return float(self._config.get("local", {}).get("timeout_seconds", 300))
 
     _WINDOW = 5
     _NEAR_DUP_THRESHOLD = 3     # same tool ≥ 3 times in window → redundant
@@ -410,22 +410,22 @@ class OllamaAgent:
             history: list | None = None, step_callback=None,
             intent_class: str | None = None, command_id: str | None = None,
             system_prompt: str | None = None) -> dict:
-        """Run Ollama tool-use loop. Raises EscalateToCloud if Ollama can't handle it.
+        """Run local tool-use loop. Raises EscalateToCloud if local executor can't handle it.
         Returns same dict shape as Agent.run(). When command_id is given and the run
         pauses for approval, a resume callable is registered so it can continue
         server-side without replaying earlier steps."""
         if system_prompt is not None:
             system_msg = system_prompt
         else:
-            system_msg = _BASE_SYSTEM_PROMPT.format(home=os.path.expanduser("~")) + _OLLAMA_EXTRA
+            system_msg = _BASE_SYSTEM_PROMPT.format(home=os.path.expanduser("~")) + _LOCAL_EXTRA
             if cwd:
                 system_msg += f"\nActive project directory: {cwd}\n"
             if memory_context:
                 system_msg += f"\nProject memory: {memory_context}\n"
 
-        max_steps = int(self._config.get("reasoning", {}).get("max_steps_ollama", 15))
+        max_steps = int(self._config.get("reasoning", {}).get("max_steps_local", 15))
 
-        state = _OllamaLoopState(
+        state = _LocalLoopState(
             messages=[
                 {"role": "system", "content": system_msg},
                 *(history or []),
@@ -445,7 +445,7 @@ class OllamaAgent:
         )
         return self._outer_loop(state, step_callback)
 
-    def resume(self, state: "_OllamaLoopState", step_callback=None) -> dict:
+    def resume(self, state: "_LocalLoopState", step_callback=None) -> dict:
         """Continue a run paused for approval: finish the paused tool batch (execute
         the now-approved tool and any remaining calls), then run the outer loop."""
         tool_calls = state.pending_tool_calls
@@ -456,7 +456,7 @@ class OllamaAgent:
             return result
         return self._outer_loop(state, step_callback)
 
-    def _outer_loop(self, state: "_OllamaLoopState", step_callback) -> dict:
+    def _outer_loop(self, state: "_LocalLoopState", step_callback) -> dict:
         url = f"{self._host}/v1/chat/completions"
         wrap_up_step = state.max_steps - 2
         try:
@@ -485,7 +485,7 @@ class OllamaAgent:
                     state.gen_metrics = call_metrics  # keep last text-generating call's metrics
 
                 if finish == "stop" or not msg.get("tool_calls"):
-                    text = _clean_ollama_text(msg.get("content") or "")
+                    text = _clean_local_text(msg.get("content") or "")
                     if not text and not state.tool_calls_made and finish != "stop":
                         # Thinking may have exhausted the token budget leaving empty content.
                         # Retry once with thinking disabled before escalating.
@@ -572,11 +572,11 @@ class OllamaAgent:
                     return result
 
         except httpx.ConnectError as e:
-            raise EscalateToCloud(f"Ollama unavailable: {e}")
+            raise EscalateToCloud(f"Local executor unavailable: {e}")
         except httpx.TimeoutException as e:
-            raise EscalateToCloud(f"Ollama timeout: {e}")
+            raise EscalateToCloud(f"Local executor timeout: {e}")
         except httpx.HTTPStatusError as e:
-            raise EscalateToCloud(f"Ollama HTTP error: {e}")
+            raise EscalateToCloud(f"Local executor HTTP error: {e}")
 
         # Salvage: one final no-tools call to emit whatever the model gathered
         try:
@@ -584,7 +584,7 @@ class OllamaAgent:
                 url, json={"model": self._model, "messages": state.messages, "tool_choice": "none"},
             )
             salvage_resp.raise_for_status()
-            salvage_text = _clean_ollama_text(
+            salvage_text = _clean_local_text(
                 salvage_resp.json()["choices"][0]["message"].get("content") or ""
             )
             if salvage_text:
@@ -598,7 +598,7 @@ class OllamaAgent:
         result["steps"] = state.steps
         return result
 
-    def _process_tools(self, state: "_OllamaLoopState", tool_calls: list, start_idx: int,
+    def _process_tools(self, state: "_LocalLoopState", tool_calls: list, start_idx: int,
                        step_callback) -> tuple[str, dict | None]:
         """Process the tool calls of one assistant turn from start_idx. Returns
         ("final", result) if it concluded, ("paused", approval) if it stopped for
@@ -659,7 +659,7 @@ class OllamaAgent:
                         url, json={"model": self._model, "messages": state.messages, "tool_choice": "none"},
                     )
                     nr.raise_for_status()
-                    nr_text = _clean_ollama_text(nr.json()["choices"][0]["message"].get("content") or "")
+                    nr_text = _clean_local_text(nr.json()["choices"][0]["message"].get("content") or "")
                     if nr_text:
                         result = format_response(nr_text, state.tool_calls_made)
                         result["steps"] = state.steps
@@ -682,7 +682,7 @@ class OllamaAgent:
                         url, json={"model": self._model, "messages": state.messages},
                     )
                     resp2.raise_for_status()
-                    text = _clean_ollama_text(resp2.json()["choices"][0]["message"].get("content") or "")
+                    text = _clean_local_text(resp2.json()["choices"][0]["message"].get("content") or "")
                     result = format_response(text, state.tool_calls_made)
                     result["steps"] = state.steps
                     return ("final", result)
@@ -708,7 +708,7 @@ class OllamaAgent:
                     approval_store.register(
                         state.command_id,
                         lambda step_callback=None, _s=state: self.resume(_s, step_callback),
-                        {"user_text": state.user_text, "agent": "ollama", "model": self._model},
+                        {"user_text": state.user_text, "agent": "local", "model": self._model},
                     )
                 return ("paused", {
                     "speak": None, "display": None,

--- a/jarvis-core/router.py
+++ b/jarvis-core/router.py
@@ -8,7 +8,7 @@ from datetime import date as _date
 from classifier_prompt import CLASSIFY_SYSTEM_PROMPT
 from git_context import get_git_context
 from guardrails import Guardrails
-from ollama_agent import OllamaAgent, EscalateToCloud
+from local_agent import LocalAgent as OllamaAgent, EscalateToCloud
 from agent import Agent, claude_code_available
 from prompt_loader import PromptLoader
 

--- a/jarvis-core/router.py
+++ b/jarvis-core/router.py
@@ -8,11 +8,11 @@ from datetime import date as _date
 from classifier_prompt import CLASSIFY_SYSTEM_PROMPT
 from git_context import get_git_context
 from guardrails import Guardrails
-from local_agent import LocalAgent as OllamaAgent, EscalateToCloud
+from local_agent import LocalAgent, EscalateToCloud
 from agent import Agent, claude_code_available
 from prompt_loader import PromptLoader
 
-_VALID_ROUTING_MODES = {"ollama_first", "claude_only", "ollama_only", "haiku_first", "local_first"}
+_VALID_ROUTING_MODES = {"local", "cloud", "automatic"}
 
 
 class Router:
@@ -23,14 +23,14 @@ class Router:
     def __init__(self, config: dict, guardrails: Guardrails, prompt_loader: PromptLoader | None = None, mcp_manager=None):
         self._config = config
         self._http_client = httpx.Client(timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=5.0))
-        self._ollama = OllamaAgent(config=config, guardrails=guardrails, mcp_manager=mcp_manager)
+        self._local = LocalAgent(config=config, guardrails=guardrails, mcp_manager=mcp_manager)
         haiku_model = config.get("models", {}).get("haiku", "claude-haiku-4-5-20251001")
         sonnet_model = config.get("models", {}).get("sonnet", "claude-sonnet-4-6")
         self._haiku = Agent(config=config, guardrails=guardrails,
-                            local_agent=self._ollama, model=haiku_model, mcp_manager=mcp_manager)
+                            local_agent=self._local, model=haiku_model, mcp_manager=mcp_manager)
         self._sonnet = Agent(config=config, guardrails=guardrails,
-                             local_agent=self._ollama, model=sonnet_model, mcp_manager=mcp_manager)
-        self._claude = self._sonnet   # legacy alias for claude_only / ollama_first modes
+                             local_agent=self._local, model=sonnet_model, mcp_manager=mcp_manager)
+        self._claude = self._sonnet   # alias kept for tests that wire _claude directly
         self._history: list[dict] = []
         self._pending_compaction_notice: bool = False
         self._needs_compaction: bool = False
@@ -51,11 +51,11 @@ class Router:
         self._last_git_context = None
         self._pending_compaction_notice = False
 
-        mode = self._config.get("ollama", {}).get("routing_mode", "ollama_first")
+        mode = self._config.get("local", {}).get("routing_mode", "automatic")
         if mode not in _VALID_ROUTING_MODES:
             logging.getLogger("jarvis.errors").warning(
                 f"Invalid routing_mode '{mode}'. Must be one of {sorted(_VALID_ROUTING_MODES)}. "
-                f"Falling back to 'ollama_first'."
+                f"Falling back to 'automatic'."
             )
 
         if not claude_code_available():
@@ -66,11 +66,11 @@ class Router:
 
     @property
     def _routing_mode(self) -> str:
-        return self._config.get("ollama", {}).get("routing_mode", "ollama_first")
+        return self._config.get("local", {}).get("routing_mode", "automatic")
 
     @property
-    def _ollama_model(self) -> str:
-        return self._config.get("ollama", {}).get("model", "mistral:latest")
+    def _local_model(self) -> str:
+        return self._config.get("local", {}).get("model", "mistral:latest")
 
     @property
     def _classifier_model(self) -> str:
@@ -83,12 +83,12 @@ class Router:
         return cfg.classifier_backend(self._config)[0]
 
     @property
-    def _ollama_host(self) -> str:
-        return self._config.get("ollama", {}).get("host", "http://localhost:11434")
+    def _local_host(self) -> str:
+        return self._config.get("local", {}).get("host", "http://localhost:11434")
 
     @property
-    def _ollama_timeout(self) -> float:
-        return float(self._config.get("ollama", {}).get("timeout_seconds", 30))
+    def _local_timeout(self) -> float:
+        return float(self._config.get("local", {}).get("timeout_seconds", 30))
 
     def _classify(self, text: str, history: list | None = None) -> dict:
         """Ask the classifier to classify intent. Returns classification dict.
@@ -250,48 +250,20 @@ class Router:
             step_callback({"type": "compacted", "message": "Context compacted."})
             self._pending_compaction_notice = False
 
-        # haiku_first: pre-flight classifies → Haiku for non-complex, Sonnet for complex_reasoning
-        if mode == "haiku_first":
-            classification = {"can_handle_locally": True, "intent_class": "read_only", "reason": "fallback"}
-            try:
-                classification = self._classify(text, history=self._history)
-            except Exception as e:
-                logging.getLogger("jarvis.errors").warning(
-                    f"Pre-flight classifier failed: {e} — using haiku"
-                )
-
-            intent_class = classification.get("intent_class", "read_only")
-            use_sonnet = intent_class == "complex_reasoning"
-            agent = self._sonnet if use_sonnet else self._haiku
-            model_name = (self._config.get("models", {}).get("sonnet", "claude-sonnet-4-6")
-                          if use_sonnet else
-                          self._config.get("models", {}).get("haiku", "claude-haiku-4-5-20251001"))
-
-            user_text = self._build_user_prefix(text, cwd, memory_context, intent_class, source)
-
-            gate = self._gate_destructive(
-                intent_class, command_id,
-                lambda sc, _a=agent, _ut=user_text, _mn=model_name: (
-                    _a.run(user_text=_ut, cwd=cwd, history=self._history, source=source,
-                           step_callback=sc, command_id=command_id,
-                           system_prompt=self._get_system_prompt(cwd))
-                ),
-                {"user_text": text, "agent": "claude", "model": model_name,
-                 "intent_class": intent_class, "escalation_reason": classification.get("reason")},
-            )
-            if gate is not None:
-                return gate
-
-            result = agent.run(user_text=user_text, cwd=cwd, history=self._history, source=source,
-                               step_callback=step_callback, command_id=command_id,
-                               system_prompt=self._get_system_prompt(cwd))
+        # cloud: skip classifier entirely, go straight to Sonnet
+        if mode == "cloud":
+            user_text = self._build_user_prefix(text, cwd, memory_context, None, source)
+            result = self._sonnet.run(user_text=user_text, cwd=cwd, history=self._history, source=source,
+                                      step_callback=step_callback, command_id=command_id,
+                                      system_prompt=self._get_system_prompt(cwd))
             self._append_turn(text, result)
+            model_name = self._config.get("models", {}).get("sonnet", "claude-sonnet-4-6")
             return self._annotate(result, agent="claude", model=model_name,
-                                  escalated=False, escalation_reason=classification.get("reason"),
-                                  intent_class=intent_class, start=start)
+                                  escalated=False, escalation_reason=None,
+                                  intent_class=None, start=start)
 
-        # local_first: pre-flight classifies → OllamaAgent for non-complex, Sonnet for complex_reasoning
-        if mode == "local_first":
+        # local: always local, suppress EscalateToCloud
+        if mode == "local":
             classification = {"can_handle_locally": True, "intent_class": "read_only", "reason": "fallback"}
             try:
                 classification = self._classify(text, history=self._history)
@@ -303,134 +275,112 @@ class Router:
             intent_class = classification.get("intent_class", "read_only")
             user_text = self._build_user_prefix(text, cwd, memory_context, intent_class, source)
 
-            if intent_class == "complex_reasoning":
-                result = self._sonnet.run(
-                    user_text=user_text, cwd=cwd, history=self._history, source=source,
-                    step_callback=step_callback, command_id=command_id,
-                    system_prompt=self._get_system_prompt(cwd),
-                )
-                self._append_turn(text, result)
-                model_name = self._config.get("models", {}).get("sonnet", "claude-sonnet-4-6")
-                return self._annotate(result, agent="claude", model=model_name,
-                                      escalated=False, escalation_reason=classification.get("reason"),
-                                      intent_class=intent_class, start=start)
-
             gate = self._gate_destructive(
                 intent_class, command_id,
-                lambda sc, _ut=user_text: self._ollama.run(
+                lambda sc, _ut=user_text: self._local.run(
                     user_text=_ut, cwd=cwd, history=self._history,
                     step_callback=sc, intent_class=intent_class, command_id=command_id,
                     system_prompt=self._get_local_system_prompt(cwd),
                 ),
-                {"user_text": text, "agent": "ollama",
-                 "model": self._config.get("ollama", {}).get("executor_model") or self._ollama_model,
+                {"user_text": text, "agent": "local",
+                 "model": self._config.get("local", {}).get("executor_model") or self._local_model,
                  "intent_class": intent_class},
             )
             if gate is not None:
                 return gate
 
-            # Non-complex: use local OllamaAgent; escalate to Sonnet on failure
             try:
-                result = self._ollama.run(
+                result = self._local.run(
                     user_text=user_text, cwd=cwd, history=self._history,
                     step_callback=step_callback, intent_class=intent_class, command_id=command_id,
                     system_prompt=self._get_local_system_prompt(cwd),
                 )
                 self._append_turn(text, result)
-                executor_model = self._config.get("ollama", {}).get("executor_model") or self._ollama_model
-                return self._annotate(result, agent="ollama", model=executor_model,
+                executor_model = self._config.get("local", {}).get("executor_model") or self._local_model
+                return self._annotate(result, agent="local", model=executor_model,
                                       escalated=False, escalation_reason=None,
                                       intent_class=intent_class, start=start)
             except EscalateToCloud as e:
                 logging.getLogger("jarvis.errors").warning(
-                    f"Local executor could not complete task: {e.reason}"
+                    f"Local executor could not complete task (suppressed): {e.reason}"
                 )
-                msg = "I wasn't able to complete that locally. Please try rephrasing or break the task into smaller steps."
+                msg = "I wasn't able to complete that locally. Please try rephrasing or restart the server if this keeps happening."
                 result = {"speak": msg, "display": msg, "steps": []}
-                return self._annotate(result, agent="ollama", model=self._ollama_model,
-                                      escalated=True, escalation_reason=f"suppressed:local_first:{e.reason}",
+                return self._annotate(result, agent="local", model=self._local_model,
+                                      escalated=True, escalation_reason=f"suppressed:local:{e.reason}",
                                       intent_class=intent_class, start=start)
 
-        # claude_only: skip classifier entirely
-        if mode == "claude_only":
-            user_text = self._build_user_prefix(text, cwd, memory_context, None, source)
-            result = self._claude.run(user_text=user_text, cwd=cwd, history=self._history, source=source,
-                                      step_callback=step_callback, command_id=command_id,
-                                      system_prompt=self._get_system_prompt(cwd))
-            self._append_turn(text, result)
-            return self._annotate(result, agent="claude", model="claude-sonnet-4-6",
-                                  escalated=False, escalation_reason=None,
-                                  intent_class=None, start=start)
-
-        # Pre-flight classification (ollama_first / ollama_only)
+        # automatic: pre-flight classifies → local for non-complex, Sonnet for complex_reasoning
+        # (this is the default branch when mode == "automatic" or unrecognised)
         classification = {"can_handle_locally": True, "intent_class": "read_only", "reason": "fallback"}
         try:
             classification = self._classify(text, history=self._history)
         except Exception as e:
             logging.getLogger("jarvis.errors").warning(
-                f"Pre-flight classifier failed: {e} — using ollama_first fallback"
+                f"Pre-flight classifier failed: {e} — using local executor"
             )
 
         intent_class = classification.get("intent_class", "read_only")
-        can_handle_locally = classification.get("can_handle_locally", True)
         user_text = self._build_user_prefix(text, cwd, memory_context, intent_class, source)
+
+        if intent_class == "complex_reasoning":
+            result = self._sonnet.run(
+                user_text=user_text, cwd=cwd, history=self._history, source=source,
+                step_callback=step_callback, command_id=command_id,
+                system_prompt=self._get_system_prompt(cwd),
+            )
+            self._append_turn(text, result)
+            model_name = self._config.get("models", {}).get("sonnet", "claude-sonnet-4-6")
+            return self._annotate(result, agent="claude", model=model_name,
+                                  escalated=False, escalation_reason=classification.get("reason"),
+                                  intent_class=intent_class, start=start)
 
         gate = self._gate_destructive(
             intent_class, command_id,
-            lambda sc, _ut=user_text: self._ollama.run(
+            lambda sc, _ut=user_text: self._local.run(
                 user_text=_ut, cwd=cwd, history=self._history,
                 step_callback=sc, intent_class=intent_class, command_id=command_id,
                 system_prompt=self._get_local_system_prompt(cwd),
             ),
-            {"user_text": text, "agent": "ollama", "model": self._ollama_model,
+            {"user_text": text, "agent": "local",
+             "model": self._config.get("local", {}).get("executor_model") or self._local_model,
              "intent_class": intent_class},
         )
         if gate is not None:
             return gate
 
-        escalation_reason = None
-        if mode == "ollama_only" or can_handle_locally:
-            try:
-                result = self._ollama.run(
-                    user_text=user_text, cwd=cwd, history=self._history,
-                    step_callback=step_callback, intent_class=intent_class, command_id=command_id,
-                    system_prompt=self._get_local_system_prompt(cwd),
-                )
-                self._append_turn(text, result)
-                return self._annotate(result, agent="ollama", model=self._ollama_model,
-                                      escalated=False, escalation_reason=None,
-                                      intent_class=intent_class, start=start)
-            except EscalateToCloud as e:
-                if mode == "ollama_only":
-                    msg = "I wasn't able to complete that locally. Please try rephrasing or restart the server if this keeps happening."
-                    result = {"speak": msg, "display": msg, "steps": []}
-                    return self._annotate(result, agent="ollama", model=self._ollama_model,
-                                          escalated=True, escalation_reason=f"suppressed:ollama_only:{e.reason}",
-                                          intent_class=intent_class, start=start)
-                # ollama_first: Ollama unavailable or escalated — fall through to Claude
-                escalation_reason = e.reason
-                logging.getLogger("jarvis.errors").warning(
-                    f"Ollama escalated to Claude: {e.reason}"
-                )
-
-        # can_handle_locally=False OR Ollama escalated: route to Claude
-        # Pass ollama_available=False when escalated so Claude doesn't waste a step on delegate_to_local
         try:
-            result = self._claude.run(
+            result = self._local.run(
                 user_text=user_text, cwd=cwd, history=self._history,
-                ollama_available=(escalation_reason is None), source=source,
-                step_callback=step_callback, command_id=command_id,
-                system_prompt=self._get_system_prompt(cwd),
+                step_callback=step_callback, intent_class=intent_class, command_id=command_id,
+                system_prompt=self._get_local_system_prompt(cwd),
             )
-        except _anthropic.APIStatusError as e:
-            logging.getLogger("jarvis.errors").error(f"Anthropic API error during cloud fallback: {e}")
-            msg = "Cloud fallback unavailable (API error). Please check your Anthropic API credits or try again later."
-            result = {"speak": msg, "display": msg, "steps": []}
-        self._append_turn(text, result)
-        return self._annotate(result, agent="claude", model="claude-sonnet-4-6",
-                              escalated=escalation_reason is not None,
-                              escalation_reason=escalation_reason or classification.get("reason"),
-                              intent_class=intent_class, start=start)
+            self._append_turn(text, result)
+            executor_model = self._config.get("local", {}).get("executor_model") or self._local_model
+            return self._annotate(result, agent="local", model=executor_model,
+                                  escalated=False, escalation_reason=None,
+                                  intent_class=intent_class, start=start)
+        except EscalateToCloud as e:
+            logging.getLogger("jarvis.errors").warning(
+                f"Local executor escalated to cloud: {e.reason}"
+            )
+            # Fall through to Sonnet
+            try:
+                result = self._sonnet.run(
+                    user_text=user_text, cwd=cwd, history=self._history,
+                    local_available=False, source=source,
+                    step_callback=step_callback, command_id=command_id,
+                    system_prompt=self._get_system_prompt(cwd),
+                )
+            except _anthropic.APIStatusError as api_err:
+                logging.getLogger("jarvis.errors").error(f"Anthropic API error during cloud fallback: {api_err}")
+                msg = "Cloud fallback unavailable (API error). Please check your Anthropic API credits or try again later."
+                result = {"speak": msg, "display": msg, "steps": []}
+            self._append_turn(text, result)
+            model_name = self._config.get("models", {}).get("sonnet", "claude-sonnet-4-6")
+            return self._annotate(result, agent="claude", model=model_name,
+                                  escalated=True, escalation_reason=e.reason,
+                                  intent_class=intent_class, start=start)
 
     def _append_turn(self, user_text: str, result: dict) -> None:
         """Append a compressed turn to history. Skip if approval_required."""

--- a/jarvis-core/server.py
+++ b/jarvis-core/server.py
@@ -50,7 +50,7 @@ def load_dependencies():
     return pipeline, loggers, guardrails, store
 
 
-def _ensure_ollama_running() -> None:
+def _ensure_local_executor_running() -> None:
     """Start ollama serve in the background if it isn't already running."""
     # When launched from a macOS app the PATH is minimal — probe Homebrew locations directly.
     ollama_bin = (
@@ -78,12 +78,12 @@ def _ensure_ollama_running() -> None:
 def _ensure_executor_server_running(config: dict) -> None:
     """Start the executor inference server if a local routing mode is active and it isn't already running.
     Uses vllm_mlx.server when executor_rapid_mlx=True, mlx_lm.server otherwise."""
-    ollama_cfg = config.get("ollama", {})
-    if ollama_cfg.get("routing_mode") not in ("local_first", "ollama_only", "ollama_first"):
+    local_cfg = config.get("local", {})
+    if local_cfg.get("routing_mode") not in ("local", "automatic"):
         return
-    base_host = ollama_cfg.get("host", "http://localhost:11434")
-    executor_host = ollama_cfg.get("executor_host", "")
-    executor_model = ollama_cfg.get("executor_model", "")
+    base_host = local_cfg.get("host", "http://localhost:11434")
+    executor_host = local_cfg.get("executor_host", "")
+    executor_model = local_cfg.get("executor_model", "")
     if not executor_host or not executor_model:
         return
     if executor_host == base_host:
@@ -100,7 +100,7 @@ def _ensure_executor_server_running(config: dict) -> None:
     parsed = urlparse(executor_host)
     port = parsed.port or 8093
 
-    if ollama_cfg.get("executor_rapid_mlx"):
+    if local_cfg.get("executor_rapid_mlx"):
         python_bin = (
             shutil.which("python3")
             or shutil.which("python")
@@ -108,7 +108,7 @@ def _ensure_executor_server_running(config: dict) -> None:
         if not python_bin:
             logging.warning("[Jarvis] python not found — skipping vllm_mlx executor auto-start")
             return
-        max_tokens = str(ollama_cfg.get("executor_max_tokens", 8192))
+        max_tokens = str(local_cfg.get("executor_max_tokens", 8192))
         cmd = [
             python_bin, "-m", "vllm_mlx.server",
             "--model", executor_model,
@@ -125,7 +125,7 @@ def _ensure_executor_server_running(config: dict) -> None:
         if not mlx_bin:
             logging.warning("[Jarvis] mlx_lm.server binary not found — skipping executor auto-start")
             return
-        chat_template_kwargs = ollama_cfg.get("executor_chat_template_kwargs", {})
+        chat_template_kwargs = local_cfg.get("executor_chat_template_kwargs", {})
         chat_template_args = json.dumps(chat_template_kwargs) if chat_template_kwargs else None
         cmd = [mlx_bin, "--model", executor_model, "--port", str(port)]
         if chat_template_args:
@@ -136,14 +136,14 @@ def _ensure_executor_server_running(config: dict) -> None:
 
 def _ensure_classifier_server_running(config: dict) -> None:
     """Start mlx_lm.server for the classifier if it runs on a separate host and isn't already up."""
-    ollama_cfg = config.get("ollama", {})
-    base_host = ollama_cfg.get("host", "http://localhost:11434")
-    classifier_host = ollama_cfg.get("classifier_host", "")
-    classifier_model = ollama_cfg.get("classifier_model", "")
+    local_cfg = config.get("local", {})
+    base_host = local_cfg.get("host", "http://localhost:11434")
+    classifier_host = local_cfg.get("classifier_host", "")
+    classifier_model = local_cfg.get("classifier_model", "")
     if not classifier_host or not classifier_model:
         return
     if classifier_host == base_host:
-        return  # classifier is on Ollama, no MLX server needed
+        return  # classifier is on local executor host, no separate MLX server needed
 
     try:
         r = httpx.get(f"{classifier_host}/v1/models", timeout=2)
@@ -166,7 +166,7 @@ def _ensure_classifier_server_running(config: dict) -> None:
 
     cmd = [mlx_bin, "--model", classifier_model, "--port", str(port)]
 
-    adapter_path = ollama_cfg.get("classifier_adapter_path", "")
+    adapter_path = local_cfg.get("classifier_adapter_path", "")
     if adapter_path and os.path.exists(adapter_path):
         cmd += ["--adapter-path", adapter_path]
 
@@ -179,7 +179,7 @@ def _ensure_classifier_server_running(config: dict) -> None:
 async def lifespan(app: FastAPI):
     global _pipeline, _loggers, _guardrails
     config = cfg_module.load()
-    _ensure_ollama_running()
+    _ensure_local_executor_running()
     _ensure_executor_server_running(config)
     _ensure_classifier_server_running(config)
     alert_bus.set_loop(asyncio.get_running_loop())

--- a/jarvis-core/tests/conftest.py
+++ b/jarvis-core/tests/conftest.py
@@ -11,12 +11,6 @@ def no_dpo_writes(tmp_path):
         yield
 
 
-@pytest.fixture(autouse=True)
-def no_dev_config():
-    """Prevent config.dev.json on disk from affecting any test."""
-    with patch("config.DEV_CONFIG_PATH", Path("/nonexistent/config.dev.json")):
-        yield
-
 
 @pytest.fixture(autouse=True)
 def no_real_http_stream():

--- a/jarvis-core/tests/conftest.py
+++ b/jarvis-core/tests/conftest.py
@@ -7,7 +7,7 @@ import httpx
 @pytest.fixture(autouse=True)
 def no_dpo_writes(tmp_path):
     """Redirect DPO captures to a temp dir so tests never write to ~/.jarvis/logs/."""
-    with patch("ollama_agent.DPO_LOG_PATH", str(tmp_path / "dpo_data.jsonl")):
+    with patch("local_agent.DPO_LOG_PATH", str(tmp_path / "dpo_data.jsonl")):
         yield
 
 

--- a/jarvis-core/tests/test_agent.py
+++ b/jarvis-core/tests/test_agent.py
@@ -881,6 +881,15 @@ def test_result_summary_capped_at_200_chars():
     assert len(result["steps"][0]["result_summary"]) <= 200
 
 
+def test_agent_run_accepts_local_available_param():
+    """Agent.run() must accept local_available keyword argument (renamed from ollama_available)."""
+    import inspect
+    from agent import Agent
+    sig = inspect.signature(Agent.run)
+    assert "local_available" in sig.parameters
+    assert "ollama_available" not in sig.parameters
+
+
 def test_wrap_up_nudge_injected_near_step_limit():
     agent = make_agent()
     agent._config["reasoning"] = {"max_steps_claude": 5}

--- a/jarvis-core/tests/test_config.py
+++ b/jarvis-core/tests/test_config.py
@@ -203,3 +203,12 @@ def test_classifier_adapter_path_loads_from_file(tmp_path, monkeypatch):
     cfg = config.load()
     assert cfg["ollama"]["classifier_adapter_path"] == "/some/adapter"
     assert cfg["ollama"]["classifier_host"] == "http://127.0.0.1:8090"  # default preserved
+
+
+def test_dev_config_overlay_is_removed():
+    """config.load() must not read config.dev.json — ~/.jarvis/config.json is the only source."""
+    import inspect
+    import config as cfg_module
+    src = inspect.getsource(cfg_module.load)
+    assert "DEV_CONFIG_PATH" not in src
+    assert "config.dev" not in src

--- a/jarvis-core/tests/test_config.py
+++ b/jarvis-core/tests/test_config.py
@@ -6,29 +6,29 @@ import config
 
 
 def test_executor_backend_prefers_executor_keys():
-    cfg = {"ollama": {"host": "http://base:11434", "model": "base",
-                      "executor_host": "http://exec:8090", "executor_model": "exec-model"}}
+    cfg = {"local": {"host": "http://base:11434", "model": "base",
+                     "executor_host": "http://exec:8090", "executor_model": "exec-model"}}
     assert config.executor_backend(cfg) == ("http://exec:8090", "exec-model")
 
 
 def test_executor_backend_falls_back_to_base():
-    cfg = {"ollama": {"host": "http://base:11434", "model": "base"}}
+    cfg = {"local": {"host": "http://base:11434", "model": "base"}}
     assert config.executor_backend(cfg) == ("http://base:11434", "base")
 
 
 def test_classifier_backend_prefers_classifier_keys():
-    cfg = {"ollama": {"host": "http://base:11434", "model": "base",
-                      "classifier_host": "http://cls:8090", "classifier_model": "cls-model"}}
+    cfg = {"local": {"host": "http://base:11434", "model": "base",
+                     "classifier_host": "http://cls:8090", "classifier_model": "cls-model"}}
     assert config.classifier_backend(cfg) == ("http://cls:8090", "cls-model")
 
 
 def test_classifier_backend_falls_back_to_base():
-    cfg = {"ollama": {"host": "http://base:11434", "model": "base"}}
+    cfg = {"local": {"host": "http://base:11434", "model": "base"}}
     assert config.classifier_backend(cfg) == ("http://base:11434", "base")
 
 
 def test_embedder_backend_defaults_to_nomic():
-    cfg = {"ollama": {"host": "http://base:11434"}}
+    cfg = {"local": {"host": "http://base:11434"}}
     assert config.embedder_backend(cfg) == ("http://base:11434", "nomic-embed-text")
 
 
@@ -68,15 +68,15 @@ def test_config_save_and_reload(tmp_path):
 def test_defaults_include_ollama_block(tmp_path, monkeypatch):
     monkeypatch.setattr("config.CONFIG_PATH", tmp_path / "config.json")
     cfg = config.load()
-    assert "ollama" in cfg
-    assert cfg["ollama"]["host"] == "http://localhost:11434"
-    assert cfg["ollama"]["model"] == "qwen3.6:35b-a3b"
-    assert cfg["ollama"]["executor_host"] == "http://127.0.0.1:8093"
-    assert cfg["ollama"]["executor_model"] == "mlx-community/Qwen3.6-35B-A3B-4bit"
-    assert cfg["ollama"]["executor_rapid_mlx"] is True
-    assert cfg["ollama"]["classifier_model"] == "mlx-community/Qwen3-4B-Instruct-2507-4bit"
-    assert cfg["ollama"]["routing_mode"] == "local_first"
-    assert cfg["ollama"]["timeout_seconds"] == 300
+    assert "local" in cfg
+    assert cfg["local"]["host"] == "http://localhost:11434"
+    assert cfg["local"]["model"] == "qwen3.6:35b-a3b"
+    assert cfg["local"]["executor_host"] == "http://127.0.0.1:8093"
+    assert cfg["local"]["executor_model"] == "mlx-community/Qwen3.6-35B-A3B-4bit"
+    assert cfg["local"]["executor_rapid_mlx"] is True
+    assert cfg["local"]["classifier_model"] == "mlx-community/Qwen3-4B-Instruct-2507-4bit"
+    assert cfg["local"]["routing_mode"] == "automatic"
+    assert cfg["local"]["timeout_seconds"] == 300
 
 
 def test_load_deep_merges_ollama(tmp_path, monkeypatch):
@@ -85,18 +85,18 @@ def test_load_deep_merges_ollama(tmp_path, monkeypatch):
         "ollama": {"model": "custom-model"}
     }))
     cfg = config.load()
-    # custom model preserved, other keys filled from defaults
-    assert cfg["ollama"]["model"] == "custom-model"
-    assert cfg["ollama"]["host"] == "http://localhost:11434"
-    assert cfg["ollama"]["routing_mode"] == "local_first"
-    assert cfg["ollama"]["classifier_model"] == "mlx-community/Qwen3-4B-Instruct-2507-4bit"
+    # legacy "ollama" key migrated to "local"; custom model preserved, other keys filled from defaults
+    assert cfg["local"]["model"] == "custom-model"
+    assert cfg["local"]["host"] == "http://localhost:11434"
+    assert cfg["local"]["routing_mode"] == "automatic"
+    assert cfg["local"]["classifier_model"] == "mlx-community/Qwen3-4B-Instruct-2507-4bit"
 
 
 def test_defaults_include_reasoning_block(tmp_path, monkeypatch):
     monkeypatch.setattr("config.CONFIG_PATH", tmp_path / "config.json")
     cfg = config.load()
     assert cfg["reasoning"]["max_steps_claude"] == 15
-    assert cfg["reasoning"]["max_steps_ollama"] == 15
+    assert cfg["reasoning"]["max_steps_local"] == 15
     assert "max_total_steps" not in cfg["reasoning"]
     assert "step_budgets" not in cfg["reasoning"]
     assert cfg["reasoning"]["stall_detection"] is True
@@ -115,7 +115,7 @@ def test_load_deep_merges_reasoning(tmp_path, monkeypatch):
     }))
     cfg = config.load()
     assert cfg["reasoning"]["max_steps_claude"] == 10
-    assert cfg["reasoning"]["max_steps_ollama"] == 15  # default preserved
+    assert cfg["reasoning"]["max_steps_local"] == 15  # default preserved
 
 
 def test_config_has_models_section(tmp_path, monkeypatch):
@@ -177,7 +177,7 @@ def test_step_voice_default_is_false():
 
 def test_classifier_adapter_path_default_is_empty():
     from config import DEFAULTS
-    assert DEFAULTS["ollama"]["classifier_adapter_path"] == ""
+    assert DEFAULTS["local"]["classifier_adapter_path"] == ""
 
 
 def test_mcp_servers_default_is_empty_list():
@@ -201,8 +201,9 @@ def test_classifier_adapter_path_loads_from_file(tmp_path, monkeypatch):
         "ollama": {"classifier_adapter_path": "/some/adapter"}
     }))
     cfg = config.load()
-    assert cfg["ollama"]["classifier_adapter_path"] == "/some/adapter"
-    assert cfg["ollama"]["classifier_host"] == "http://127.0.0.1:8090"  # default preserved
+    # legacy "ollama" key migrated to "local"
+    assert cfg["local"]["classifier_adapter_path"] == "/some/adapter"
+    assert cfg["local"]["classifier_host"] == "http://127.0.0.1:8090"  # default preserved
 
 
 def test_dev_config_overlay_is_removed():
@@ -212,3 +213,42 @@ def test_dev_config_overlay_is_removed():
     src = inspect.getsource(cfg_module.load)
     assert "DEV_CONFIG_PATH" not in src
     assert "config.dev" not in src
+
+
+def test_config_local_key_is_used():
+    """Config must use 'local' key not 'ollama'."""
+    cfg = config.load()
+    assert "local" in cfg
+    assert "ollama" not in cfg
+    assert cfg["local"]["routing_mode"] == "automatic"
+
+
+def test_config_migrates_ollama_key_to_local(tmp_path, monkeypatch):
+    """Loading a config with legacy 'ollama' key must migrate it to 'local'."""
+    monkeypatch.setattr("config.CONFIG_PATH", tmp_path / "config.json")
+    import json
+    (tmp_path / "config.json").write_text(json.dumps({
+        "ollama": {"model": "oldmodel", "routing_mode": "local_first"}
+    }))
+    cfg = config.load()
+    assert "local" in cfg
+    assert cfg["local"]["model"] == "oldmodel"
+    assert cfg["local"]["routing_mode"] == "automatic"
+
+
+def test_config_migrates_ollama_mode_values(tmp_path, monkeypatch):
+    """Legacy mode values must be migrated: ollama_only→local, claude_only→cloud."""
+    monkeypatch.setattr("config.CONFIG_PATH", tmp_path / "config.json")
+    import json
+    (tmp_path / "config.json").write_text(json.dumps({
+        "local": {"routing_mode": "ollama_only"}
+    }))
+    cfg = config.load()
+    assert cfg["local"]["routing_mode"] == "local"
+
+
+def test_config_max_steps_local():
+    """reasoning.max_steps_local must exist (renamed from max_steps_ollama)."""
+    cfg = config.load()
+    assert "max_steps_local" in cfg["reasoning"]
+    assert "max_steps_ollama" not in cfg["reasoning"]

--- a/jarvis-core/tests/test_local_agent.py
+++ b/jarvis-core/tests/test_local_agent.py
@@ -2,7 +2,7 @@ import json
 import pytest
 from unittest.mock import MagicMock, patch
 from guardrails import Guardrails
-from ollama_agent import OllamaAgent, EscalateToCloud, _anthropic_to_ollama_tools
+from local_agent import LocalAgent, EscalateToCloud, _anthropic_to_local_tools
 
 
 # ── helper: build a fake Ollama HTTP response ─────────────────────────────────
@@ -39,18 +39,18 @@ def agent(tmp_path, monkeypatch):
     import config
     cfg = config.load()
     guardrails = Guardrails(cfg)
-    return OllamaAgent(config=cfg, guardrails=guardrails)
+    return LocalAgent(config=cfg, guardrails=guardrails)
 
 
 # ── tool schema translation ───────────────────────────────────────────────────
 
-def test_anthropic_to_ollama_tools_converts_schema():
+def test_anthropic_to_local_tools_converts_schema():
     anthropic_tools = [{
         "name": "shell_run",
         "description": "Run a shell command",
         "input_schema": {"type": "object", "properties": {"command": {"type": "string"}}, "required": ["command"]}
     }]
-    result = _anthropic_to_ollama_tools(anthropic_tools)
+    result = _anthropic_to_local_tools(anthropic_tools)
     assert result[0]["type"] == "function"
     assert result[0]["function"]["name"] == "shell_run"
     assert result[0]["function"]["parameters"]["properties"]["command"]["type"] == "string"
@@ -58,7 +58,7 @@ def test_anthropic_to_ollama_tools_converts_schema():
 
 # ── happy path: Ollama returns final answer immediately ───────────────────────
 
-def test_run_returns_response_when_ollama_answers(agent):
+def test_run_returns_response_when_local_answers(agent):
     with patch("httpx.Client.post", return_value=_stop_response("Your Downloads are empty.")):
         result = agent.run("list my Downloads", cwd=None)
     assert result["speak"] == "Your Downloads are empty."
@@ -79,10 +79,10 @@ def test_run_executes_tool_and_returns_response(agent):
     assert result["speak"] == "You have 3 files in Downloads."
 
 
-# ── ollama_only mode: no escalation raised, just max-iter response ────────────
+# ── local mode: no escalation raised, just max-iter response ────────────
 
-def test_run_in_ollama_only_mode_does_not_raise_escalate(agent):
-    agent._config["ollama"]["routing_mode"] = "ollama_only"
+def test_run_in_local_mode_does_not_raise_escalate(agent):
+    agent._config["local"]["routing_mode"] = "local"
     responses = [
         _tool_response("escalate_to_claude", {"reason": "requires web search"}, "call_1"),
         _stop_response("I cannot search the web in offline mode."),
@@ -94,7 +94,7 @@ def test_run_in_ollama_only_mode_does_not_raise_escalate(agent):
 
 # ── connection error: Ollama not running ──────────────────────────────────────
 
-def test_run_raises_escalate_when_ollama_unreachable(agent):
+def test_run_raises_escalate_when_local_unreachable(agent):
     import httpx
     with patch("httpx.Client.post", side_effect=httpx.ConnectError("connection refused")):
         with pytest.raises(EscalateToCloud) as exc_info:
@@ -104,7 +104,7 @@ def test_run_raises_escalate_when_ollama_unreachable(agent):
 
 # ── timeout: Ollama too slow (model loading) ─────────────────────────────────
 
-def test_run_raises_escalate_when_ollama_times_out(agent):
+def test_run_raises_escalate_when_local_times_out(agent):
     import httpx
     with patch("httpx.Client.post", side_effect=httpx.ReadTimeout("timed out")):
         with pytest.raises(EscalateToCloud) as exc_info:
@@ -134,7 +134,7 @@ def test_run_recovers_from_malformed_tool_arguments(agent):
 
 # ── HTTP error: Ollama returns 503 (model not loaded) ─────────────────────────
 
-def test_run_raises_escalate_when_ollama_returns_http_error(agent):
+def test_run_raises_escalate_when_local_returns_http_error(agent):
     import httpx
     mock_resp = MagicMock()
     mock_resp.status_code = 503
@@ -169,12 +169,12 @@ def test_run_returns_approval_required_when_guardrails_block(agent):
 
 # ── delegate_to_claude_code is not offered to Ollama ─────────────────────────
 
-def test_ollama_tools_exclude_delegate_to_claude_code():
-    from ollama_agent import _OLLAMA_TOOLS
-    names = [t["function"]["name"] for t in _OLLAMA_TOOLS]
+def test_local_tools_exclude_delegate_to_claude_code():
+    from local_agent import _LOCAL_TOOLS
+    names = [t["function"]["name"] for t in _LOCAL_TOOLS]
     assert "delegate_to_claude_code" not in names
     assert "escalate_to_claude" not in names   # removed: pre-flight classifier handles routing
-    assert "delegate_to_local" not in names    # Claude-only tool: Ollama is the delegate, not the delegator
+    assert "delegate_to_local" not in names    # Claude-only tool: LocalAgent is the delegate, not the delegator
 
 
 def test_run_injects_memory_context_into_messages(agent):
@@ -223,9 +223,9 @@ def test_salvage_call_on_step_exhaustion(agent):
             call_num[0] += 1
         return resp
 
-    agent._config["reasoning"]["max_steps_ollama"] = 3
+    agent._config["reasoning"]["max_steps_local"] = 3
     with patch.object(agent._http_client, "post", side_effect=fake_post):
-        with patch("ollama_agent.execute_tool", return_value="file list"):
+        with patch("local_agent.execute_tool", return_value="file list"):
             result = agent.run("what are my specs")
 
     assert len(salvage_calls) >= 1, "Salvage call should have been made after exhausting steps"
@@ -258,10 +258,10 @@ def test_salvage_falls_back_to_error_if_empty(agent):
             call_num[0] += 1
         return resp
 
-    agent._config["reasoning"]["max_steps_ollama"] = 3
+    agent._config["reasoning"]["max_steps_local"] = 3
     agent._config["reasoning"]["stall_detection"] = False
     with patch.object(agent._http_client, "post", side_effect=fake_post):
-        with patch("ollama_agent.execute_tool", return_value="ok"):
+        with patch("local_agent.execute_tool", return_value="ok"):
             result = agent.run("do stuff")
 
     assert result["speak"] == "I ran out of steps. Please try again."
@@ -317,9 +317,9 @@ def test_finalize_tool_stops_before_step_limit(agent):
             }}]}
         return resp
 
-    agent._config["reasoning"]["max_steps_ollama"] = 10
+    agent._config["reasoning"]["max_steps_local"] = 10
     with patch.object(agent._http_client, "post", side_effect=fake_post):
-        with patch("ollama_agent.execute_tool", return_value="arm64"):
+        with patch("local_agent.execute_tool", return_value="arm64"):
             result = agent.run("what chip do I have")
 
     assert "M1 Max" in result["speak"]
@@ -327,10 +327,10 @@ def test_finalize_tool_stops_before_step_limit(agent):
     assert len(result["steps"]) == 2
 
 
-# ── max_steps_ollama controls step limit ──────────────────────────────────────
+# ── max_steps_local controls step limit ──────────────────────────────────────
 
-def test_max_steps_ollama_controls_step_limit(agent):
-    """max_steps_ollama limits total tool calls regardless of intent_class."""
+def test_max_steps_local_controls_step_limit(agent):
+    """max_steps_local limits total tool calls regardless of intent_class."""
     call_count = [0]
     commands = [f"ls /dir{i}" for i in range(20)]
 
@@ -351,19 +351,19 @@ def test_max_steps_ollama_controls_step_limit(agent):
             }}]}
         return resp
 
-    agent._config["reasoning"]["max_steps_ollama"] = 3
+    agent._config["reasoning"]["max_steps_local"] = 3
     with patch.object(agent._http_client, "post", side_effect=fake_post):
-        with patch("ollama_agent.execute_tool", return_value="ok"):
+        with patch("local_agent.execute_tool", return_value="ok"):
             agent.run("do something")
 
     # 3 tool calls + salvage = ≤ 5 total API calls
     assert call_count[0] <= 5
 
 
-def test_finalize_tool_is_in_ollama_tools_schema(agent):
+def test_finalize_tool_is_in_local_tools_schema(agent):
     """finalize tool should be present in the tools sent to Ollama."""
-    from ollama_agent import _OLLAMA_TOOLS
-    tool_names = [t["function"]["name"] for t in _OLLAMA_TOOLS]
+    from local_agent import _LOCAL_TOOLS
+    tool_names = [t["function"]["name"] for t in _LOCAL_TOOLS]
     assert "finalize" in tool_names
 
 
@@ -400,9 +400,9 @@ def test_near_duplicate_detection_stops_redundant_loop(agent):
             }}]}
         return resp
 
-    agent._config["reasoning"]["max_steps_ollama"] = 10
+    agent._config["reasoning"]["max_steps_local"] = 10
     with patch.object(agent._http_client, "post", side_effect=fake_post):
-        with patch("ollama_agent.execute_tool", return_value="   100"):
+        with patch("local_agent.execute_tool", return_value="   100"):
             result = agent.run("how many python files")
 
     assert len(result["steps"]) < 10, "Should have stopped before using all 10 steps"
@@ -412,8 +412,8 @@ def test_near_duplicate_detection_stops_redundant_loop(agent):
 
 # ── coding agent wiring ───────────────────────────────────────────────────────
 
-def test_ollama_agent_has_no_coding_agent(agent):
-    """OllamaAgent must not expose a coding agent — coding tools are disabled."""
+def test_local_agent_has_no_coding_agent(agent):
+    """LocalAgent must not expose a coding agent — coding tools are disabled."""
     assert not hasattr(agent, "_coding")
 
 
@@ -424,17 +424,17 @@ def test_coding_ask_not_in_tool_schema(agent):
     assert "coding_ask" not in names
 
 
-def test_coding_tools_excluded_from_ollama_schema():
-    """coding_ask, coding_plan, coding_review must not appear in OllamaAgent's tool schema."""
-    from ollama_agent import _OLLAMA_TOOLS
-    tool_names = [t["function"]["name"] for t in _OLLAMA_TOOLS]
+def test_coding_tools_excluded_from_local_schema():
+    """coding_ask, coding_plan, coding_review must not appear in LocalAgent's tool schema."""
+    from local_agent import _LOCAL_TOOLS
+    tool_names = [t["function"]["name"] for t in _LOCAL_TOOLS]
     assert "coding_ask" not in tool_names
     assert "coding_plan" not in tool_names
     assert "coding_review" not in tool_names
 
 
 def test_http_client_uses_split_timeout(agent):
-    """OllamaAgent._http_client must use httpx.Timeout with short connect and long read."""
+    """LocalAgent._http_client must use httpx.Timeout with short connect and long read."""
     import httpx
     t = agent._http_client.timeout
     assert isinstance(t, httpx.Timeout), "Expected httpx.Timeout, not a flat number"
@@ -448,9 +448,9 @@ def test_timeout_seconds_config_sets_read_timeout(tmp_path, monkeypatch):
     monkeypatch.setattr("config.CONFIG_PATH", tmp_path / "config.json")
     import config
     cfg = config.load()
-    cfg["ollama"]["timeout_seconds"] = 120
+    cfg["local"]["timeout_seconds"] = 120
     from guardrails import Guardrails
-    a = OllamaAgent(config=cfg, guardrails=Guardrails(cfg))
+    a = LocalAgent(config=cfg, guardrails=Guardrails(cfg))
     assert a._http_client.timeout.read == 120.0
     assert a._http_client.timeout.connect <= 10.0
 
@@ -464,7 +464,7 @@ def test_step_callback_fired_for_all_steps_not_just_first(agent):
     ]
     step_events = []
     with patch("httpx.Client.post", side_effect=responses):
-        with patch("ollama_agent.execute_tool", return_value="ok"):
+        with patch("local_agent.execute_tool", return_value="ok"):
             agent.run("list dirs", step_callback=lambda e: step_events.append(e))
 
     step_type_events = [e for e in step_events if e["type"] == "step"]
@@ -482,7 +482,7 @@ def test_non_milestone_step_event_has_correct_fields(agent):
     ]
     step_events = []
     with patch("httpx.Client.post", side_effect=responses):
-        with patch("ollama_agent.execute_tool", return_value="ok"):
+        with patch("local_agent.execute_tool", return_value="ok"):
             agent.run("do stuff", step_callback=lambda e: step_events.append(e))
 
     non_milestones = [e for e in step_events if e.get("type") == "step" and not e["milestone"]]
@@ -494,7 +494,7 @@ def test_non_milestone_step_event_has_correct_fields(agent):
     assert e["milestone"] is False
 
 
-from ollama_agent import _stream_call
+from local_agent import _stream_call
 import json as _json_mod
 
 
@@ -618,7 +618,7 @@ def test_run_no_spurious_token_events_during_tool_call_round(agent):
         return _mock_stream(stop_lines)
 
     with patch.object(agent._http_client, "stream", side_effect=fake_stream):
-        with patch("ollama_agent.execute_tool", return_value="file list"):
+        with patch("local_agent.execute_tool", return_value="file list"):
             agent.run("list files", step_callback=lambda e: events.append(e))
 
     # Verify zero tokens emitted during the tool call round (before first step event)
@@ -655,7 +655,7 @@ def test_coding_agent_passed_as_none_to_execute_tool(agent):
         return "hi"
 
     with patch.object(agent._http_client, "post", side_effect=fake_post):
-        with patch("ollama_agent.execute_tool", side_effect=capturing_execute_tool):
+        with patch("local_agent.execute_tool", side_effect=capturing_execute_tool):
             agent.run("echo hi")
 
     assert captured.get("coding") is None
@@ -663,9 +663,9 @@ def test_coding_agent_passed_as_none_to_execute_tool(agent):
 
 # ── MCP dynamic tool injection ────────────────────────────────────────────────
 
-def test_ollama_agent_includes_mcp_tools_in_tool_list():
+def test_local_agent_includes_mcp_tools_in_tool_list():
     from tools.mcp import MCPManager
-    a = OllamaAgent({"anthropic_api_key": "x", "brave_api_key": None}, Guardrails({}))
+    a = LocalAgent({"anthropic_api_key": "x", "brave_api_key": None}, Guardrails({}))
     mgr = MCPManager([{"name": "fs", "command": "npx", "args": [], "transport": "stdio"}])
     t = MagicMock()
     t.name = "read_file"
@@ -679,8 +679,8 @@ def test_ollama_agent_includes_mcp_tools_in_tool_list():
     assert "shell_run" in names
 
 
-def test_ollama_agent_build_tool_list_without_mcp_returns_only_builtins():
-    a = OllamaAgent({"anthropic_api_key": "x", "brave_api_key": None}, Guardrails({}))
+def test_local_agent_build_tool_list_without_mcp_returns_only_builtins():
+    a = LocalAgent({"anthropic_api_key": "x", "brave_api_key": None}, Guardrails({}))
     a._mcp_manager = None
     tools = a._build_tool_list()
     names = [tool["function"]["name"] for tool in tools]
@@ -688,12 +688,12 @@ def test_ollama_agent_build_tool_list_without_mcp_returns_only_builtins():
     assert not any(n.startswith("mcp__") for n in names)
 
 
-def test_ollama_agent_passes_mcp_manager_to_execute_tool():
-    """OllamaAgent must pass mcp_manager when dispatching MCP tool calls."""
+def test_local_agent_passes_mcp_manager_to_execute_tool():
+    """LocalAgent must pass mcp_manager when dispatching MCP tool calls."""
     from tools.mcp import MCPManager
     import tools._dispatch as dispatch_mod
 
-    a = OllamaAgent({"anthropic_api_key": "x", "brave_api_key": None}, Guardrails({"guardrails": {"mcp_tool": "auto_allow"}}))
+    a = LocalAgent({"anthropic_api_key": "x", "brave_api_key": None}, Guardrails({"guardrails": {"mcp_tool": "auto_allow"}}))
     mgr = MCPManager([{"name": "gh", "command": "x", "args": [], "transport": "stdio"}])
     t = MagicMock(); t.name = "list_issues"; t.description = ""; t.inputSchema = {"type": "object", "properties": {}}
     mgr._inject_tools("gh", [t])
@@ -713,7 +713,7 @@ def test_ollama_agent_passes_mcp_manager_to_execute_tool():
         return "[]"
 
     with patch.object(a._http_client, "post", side_effect=fake_post):
-        with patch("ollama_agent.execute_tool", side_effect=spy_execute):
+        with patch("local_agent.execute_tool", side_effect=spy_execute):
             a.run("list issues")
 
     assert captured.get("mcp_manager") is mgr
@@ -721,7 +721,7 @@ def test_ollama_agent_passes_mcp_manager_to_execute_tool():
 
 # ── Task 12: result_summary cap and wrap-up nudge ─────────────────────────────
 
-def test_ollama_result_summary_capped_at_200_chars(agent):
+def test_local_result_summary_capped_at_200_chars(agent):
     long_result = "y" * 300
     tool_resp = _tool_response("shell_run", {"command": "ls"})
     stop_resp = _stop_response("Done.")
@@ -734,14 +734,14 @@ def test_ollama_result_summary_capped_at_200_chars(agent):
     stream_mock = MagicMock(side_effect=ValueError("force fallback to post"))
     with patch.object(agent._http_client, "stream", stream_mock):
         with patch.object(agent._http_client, "post", side_effect=fake_post):
-            with patch("ollama_agent.execute_tool", return_value=long_result):
+            with patch("local_agent.execute_tool", return_value=long_result):
                 result = agent.run("list files")
 
     assert len(result["steps"][0]["result_summary"]) <= 200
 
 
-def test_ollama_wrap_up_nudge_injected_near_step_limit(agent):
-    agent._config["reasoning"]["max_steps_ollama"] = 5
+def test_local_wrap_up_nudge_injected_near_step_limit(agent):
+    agent._config["reasoning"]["max_steps_local"] = 5
     agent._config["reasoning"]["stall_detection"] = False  # avoid near-dup terminating early
     call_payloads = []
     # Alternate tool names to also avoid near-duplicate detection
@@ -767,7 +767,7 @@ def test_ollama_wrap_up_nudge_injected_near_step_limit(agent):
     stream_mock = MagicMock(side_effect=ValueError("force fallback to post"))
     with patch.object(agent._http_client, "stream", stream_mock):
         with patch.object(agent._http_client, "post", side_effect=fake_post):
-            with patch("ollama_agent.execute_tool", return_value="ok"):
+            with patch("local_agent.execute_tool", return_value="ok"):
                 agent.run("do stuff")
 
     assert len(call_payloads) >= 4
@@ -782,7 +782,7 @@ def test_ollama_wrap_up_nudge_injected_near_step_limit(agent):
 
 def test_planning_text_triggers_nudge_then_tool_call(agent):
     """Model returns 'Let me check...' first, then a real tool call after nudge."""
-    from ollama_agent import _is_planning_text
+    from local_agent import _is_planning_text
     assert _is_planning_text("Let me fetch the PR diff.")
     assert _is_planning_text("I'll check the CI failures for you.")
     assert not _is_planning_text("Done.")
@@ -806,7 +806,7 @@ def test_planning_text_triggers_nudge_then_tool_call(agent):
     stream_mock = MagicMock(side_effect=ValueError("force fallback"))
     with patch.object(agent._http_client, "stream", stream_mock):
         with patch.object(agent._http_client, "post", side_effect=fake_post):
-            with patch("ollama_agent.execute_tool", return_value="ok"):
+            with patch("local_agent.execute_tool", return_value="ok"):
                 result = agent.run("check CI", step_callback=fake_step)
 
     assert captured_nudge[0], "clear SSE event not emitted on nudge"
@@ -820,7 +820,7 @@ def test_planning_text_escalates_after_2_retries(agent):
     with patch.object(agent._http_client, "stream", stream_mock):
         with patch.object(agent._http_client, "post",
                           return_value=_stop_response("Let me check that for you.")):
-            from ollama_agent import EscalateToCloud
+            from local_agent import EscalateToCloud
             with pytest.raises(EscalateToCloud):
                 agent.run("check something")
 
@@ -840,7 +840,7 @@ def _make_streaming_finalize_response(answer: str, call_id: str = "call_fin"):
 
 def test_finalize_streams_answer_as_tokens(agent):
     """When Ollama calls finalize(answer=...), the answer must be streamed as token events."""
-    from ollama_agent import _stream_call
+    from local_agent import _stream_call
     answer = "Here is your code review: looks great overall."
     lines = _make_streaming_finalize_response(answer)
 
@@ -860,7 +860,7 @@ def test_finalize_streams_answer_as_tokens(agent):
 
 def test_finalize_emits_composing_step_before_tokens(agent):
     """A 'Composing response…' step event must fire before the first token of a finalize answer."""
-    from ollama_agent import _stream_call
+    from local_agent import _stream_call
     lines = _make_streaming_finalize_response("The answer is 42.")
 
     events = []
@@ -903,7 +903,7 @@ def test_planning_text_after_tool_calls_triggers_nudge(agent):
     stream_mock = MagicMock(side_effect=ValueError("force fallback"))
     with patch.object(agent._http_client, "stream", stream_mock):
         with patch.object(agent._http_client, "post", side_effect=fake_post):
-            with patch("ollama_agent.execute_tool", return_value='[{"number":39}]'):
+            with patch("local_agent.execute_tool", return_value='[{"number":39}]'):
                 result = agent.run("check PRs", step_callback=fake_step)
 
     assert nudge_fired[0], "clear SSE not emitted when planning text followed tool calls"
@@ -1099,7 +1099,7 @@ def test_nudge_dpo_capture_records_rejected_response(agent, tmp_path):
     stream_mock = MagicMock(side_effect=ValueError("force fallback to post"))
     with patch.object(agent._http_client, "stream", stream_mock):
         with patch.object(agent._http_client, "post", side_effect=fake_post):
-            with patch("ollama_agent.DPO_LOG_PATH", str(dpo_log)):  # override conftest redirect
+            with patch("local_agent.DPO_LOG_PATH", str(dpo_log)):  # override conftest redirect
                 agent.run("organize my files", command_id="test-cmd-1")
 
     assert dpo_log.exists(), "DPO log file must be created on nudge"
@@ -1129,8 +1129,8 @@ def test_nudge_dpo_capture_records_chosen_when_retry_calls_tool(agent, tmp_path)
     stream_mock = MagicMock(side_effect=ValueError("force fallback to post"))
     with patch.object(agent._http_client, "stream", stream_mock):
         with patch.object(agent._http_client, "post", side_effect=fake_post):
-            with patch("ollama_agent.execute_tool", return_value="a.txt\nb.txt"):
-                with patch("ollama_agent.DPO_LOG_PATH", str(dpo_log)):  # override conftest redirect
+            with patch("local_agent.execute_tool", return_value="a.txt\nb.txt"):
+                with patch("local_agent.DPO_LOG_PATH", str(dpo_log)):  # override conftest redirect
                     agent.run("list downloads", command_id="test-cmd-2")
 
     records = [json.loads(line) for line in dpo_log.read_text().splitlines()]
@@ -1153,7 +1153,7 @@ def test_nudge_dpo_no_capture_when_model_calls_tool_directly(agent, tmp_path):
     ]
     with patch("httpx.Client.post", side_effect=responses):
         with patch.object(agent._shell, "run", return_value={"exit_code": 0, "stdout": "a.txt", "stderr": ""}):
-            with patch("ollama_agent.DPO_LOG_PATH", str(dpo_log)):  # override conftest redirect
+            with patch("local_agent.DPO_LOG_PATH", str(dpo_log)):  # override conftest redirect
                 agent.run("list downloads")
 
     assert not dpo_log.exists(), "DPO log must not be created when no nudge fires"

--- a/jarvis-core/tests/test_router.py
+++ b/jarvis-core/tests/test_router.py
@@ -3,7 +3,7 @@ import pytest
 from datetime import date
 from unittest.mock import MagicMock, patch
 from guardrails import Guardrails
-from ollama_agent import EscalateToCloud
+from local_agent import EscalateToCloud
 from router import Router
 from prompt_loader import PromptLoader
 
@@ -332,7 +332,7 @@ def test_local_first_uses_sonnet_for_complex_reasoning(local_first_router, mock_
 
 def test_local_first_stays_local_on_escalate(local_first_router, mock_ollama_agent, mock_sonnet_agent):
     """In local_first mode, OllamaAgent failure must return a graceful message — never call cloud."""
-    from ollama_agent import EscalateToCloud
+    from local_agent import EscalateToCloud
     local_first_router._classify = MagicMock(return_value={
         "can_handle_locally": True, "intent_class": "read_only", "reason": "simple"
     })

--- a/jarvis-core/tests/test_router.py
+++ b/jarvis-core/tests/test_router.py
@@ -8,7 +8,7 @@ from router import Router
 from prompt_loader import PromptLoader
 
 
-# ── fixture ───────────────────────────────────────────────────────────────────
+# ── fixtures ───────────────────────────────────────────────────────────────────
 
 @pytest.fixture
 def config(tmp_path, monkeypatch):
@@ -18,7 +18,7 @@ def config(tmp_path, monkeypatch):
 
 
 @pytest.fixture
-def mock_ollama_agent():
+def mock_local_agent():
     agent = MagicMock()
     agent.run.return_value = {"speak": "Done locally.", "display": "Done locally.", "error": None}
     return agent
@@ -32,11 +32,12 @@ def mock_claude_agent():
 
 
 @pytest.fixture
-def router(config, mock_ollama_agent, mock_claude_agent):
-    config["ollama"]["routing_mode"] = "ollama_first"
+def router(config, mock_local_agent, mock_claude_agent):
+    # Default fixture: automatic mode
+    config["local"]["routing_mode"] = "automatic"
     guardrails = Guardrails(config)
     r = Router(config=config, guardrails=guardrails)
-    r._ollama = mock_ollama_agent
+    r._local = mock_local_agent
     r._claude = mock_claude_agent
     r._sonnet = mock_claude_agent
     # Pre-flight classifier is mocked by default; individual tests can override
@@ -44,11 +45,11 @@ def router(config, mock_ollama_agent, mock_claude_agent):
     return r
 
 
-# ── routing_mode: ollama_first ────────────────────────────────────────────────
+# ── routing_mode: automatic ───────────────────────────────────────────────────
 
-def test_ollama_first_uses_ollama_when_successful(router, mock_ollama_agent, mock_claude_agent):
+def test_automatic_uses_local_when_successful(router, mock_local_agent, mock_claude_agent):
     result = router.process("list Downloads", cwd=None)
-    called_kwargs = mock_ollama_agent.run.call_args.kwargs
+    called_kwargs = mock_local_agent.run.call_args.kwargs
     assert called_kwargs["cwd"] is None
     assert "memory_context" not in called_kwargs  # now baked into user_text prefix
     assert isinstance(called_kwargs["history"], list)
@@ -56,30 +57,30 @@ def test_ollama_first_uses_ollama_when_successful(router, mock_ollama_agent, moc
     assert result["speak"] == "Done locally."
 
 
-def test_ollama_first_falls_back_to_claude_when_ollama_unreachable(router, mock_ollama_agent, mock_claude_agent):
-    """When Ollama raises EscalateToCloud in ollama_first mode, router falls through to Claude."""
-    mock_ollama_agent.run.side_effect = EscalateToCloud("connection refused")
+def test_automatic_falls_back_to_sonnet_when_local_escalates(router, mock_local_agent, mock_claude_agent):
+    """When local raises EscalateToCloud in automatic mode, router falls through to Sonnet."""
+    mock_local_agent.run.side_effect = EscalateToCloud("connection refused")
     result = router.process("open Safari", cwd=None)
     mock_claude_agent.run.assert_called_once()
     assert result["_agent"] == "claude"
     assert result["_escalated"] is True
 
 
-# ── routing_mode: claude_only ─────────────────────────────────────────────────
+# ── routing_mode: cloud ───────────────────────────────────────────────────────
 
-def test_claude_only_skips_ollama(router, mock_ollama_agent, mock_claude_agent, config):
-    config["ollama"]["routing_mode"] = "claude_only"
+def test_cloud_mode_skips_local(router, mock_local_agent, mock_claude_agent, config):
+    config["local"]["routing_mode"] = "cloud"
     result = router.process("any command", cwd=None)
-    mock_ollama_agent.run.assert_not_called()
+    mock_local_agent.run.assert_not_called()
     mock_claude_agent.run.assert_called_once()
     assert result["speak"] == "Done via Claude."
 
 
-# ── routing_mode: ollama_only ─────────────────────────────────────────────────
+# ── routing_mode: local ───────────────────────────────────────────────────────
 
-def test_ollama_only_never_calls_claude(router, mock_ollama_agent, mock_claude_agent, config):
-    config["ollama"]["routing_mode"] = "ollama_only"
-    mock_ollama_agent.run.return_value = {"speak": "Best I can do offline.", "display": "Best I can do offline."}
+def test_local_mode_never_calls_cloud(router, mock_local_agent, mock_claude_agent, config):
+    config["local"]["routing_mode"] = "local"
+    mock_local_agent.run.return_value = {"speak": "Best I can do offline.", "display": "Best I can do offline."}
     result = router.process("search the web", cwd=None)
     mock_claude_agent.run.assert_not_called()
     assert result["speak"] == "Best I can do offline."
@@ -89,7 +90,7 @@ def test_ollama_only_never_calls_claude(router, mock_ollama_agent, mock_claude_a
 
 def test_process_returns_agent_metadata(router):
     result = router.process("list Downloads", cwd=None)
-    assert result.get("_agent") == "ollama"
+    assert result.get("_agent") == "local"
     assert result.get("_escalated") is False
     assert isinstance(result.get("_response_ms"), int)
 
@@ -97,39 +98,45 @@ def test_process_returns_agent_metadata(router):
 def test_process_returns_intent_class_in_metadata(router):
     """Intent class from pre-flight classifier should appear in response metadata."""
     result = router.process("list Downloads", cwd=None)
-    assert result.get("_agent") == "ollama"
+    assert result.get("_agent") == "local"
     assert result.get("_escalated") is False
     assert result.get("_intent_class") == "read_only"
 
 
-def test_ollama_only_guard_records_escalation_truthfully(router, mock_ollama_agent, mock_claude_agent, config):
-    """If OllamaAgent leaks EscalateToCloud in ollama_only mode, router must not call Claude
+def test_local_mode_guard_records_escalation_truthfully(router, mock_local_agent, mock_claude_agent, config):
+    """If LocalAgent leaks EscalateToCloud in local mode, router must not call cloud
     and must record escalated=True with the suppression reason."""
-    config["ollama"]["routing_mode"] = "ollama_only"
-    mock_ollama_agent.run.side_effect = EscalateToCloud("unexpected reason")
+    config["local"]["routing_mode"] = "local"
+    mock_local_agent.run.side_effect = EscalateToCloud("unexpected reason")
     result = router.process("something", cwd=None)
     mock_claude_agent.run.assert_not_called()
     assert result.get("_escalated") is True
-    assert "suppressed:ollama_only" in result.get("_escalation_reason", "")
+    assert "suppressed:local" in result.get("_escalation_reason", "")
 
 
-def test_ollama_only_with_unreachable_ollama_does_not_call_claude(router, mock_ollama_agent, mock_claude_agent, config):
-    """When Ollama is unreachable in ollama_only mode, Router must not escalate to Claude."""
-    config["ollama"]["routing_mode"] = "ollama_only"
-    mock_ollama_agent.run.side_effect = EscalateToCloud("Ollama unavailable: connection refused")
+def test_local_mode_with_unreachable_local_does_not_call_cloud(router, mock_local_agent, mock_claude_agent, config):
+    """When local is unreachable in local mode, Router must not escalate to cloud."""
+    config["local"]["routing_mode"] = "local"
+    mock_local_agent.run.side_effect = EscalateToCloud("unavailable: connection refused")
     result = router.process("open Safari", cwd=None)
     mock_claude_agent.run.assert_not_called()
     assert result.get("_escalated") is True
-    assert "suppressed:ollama_only" in result.get("_escalation_reason", "")
+    assert "suppressed:local" in result.get("_escalation_reason", "")
     assert result.get("speak") is not None  # returned something, not None
 
 
 # ── routing_mode validation ───────────────────────────────────────────────────
 
+def test_valid_modes_are_local_cloud_automatic():
+    """Only local, cloud, automatic are valid routing modes."""
+    from router import _VALID_ROUTING_MODES
+    assert _VALID_ROUTING_MODES == {"local", "cloud", "automatic"}
+
+
 def test_invalid_routing_mode_logs_warning(config):
     """Invalid routing_mode should log a warning, not crash."""
     import logging
-    config["ollama"]["routing_mode"] = "invalid_mode"
+    config["local"]["routing_mode"] = "invalid_mode"
     guardrails = Guardrails(config)
     # Should not raise — warning goes to named logger (jarvis.errors), not root logger
     r = Router(config=config, guardrails=guardrails)
@@ -138,7 +145,7 @@ def test_invalid_routing_mode_logs_warning(config):
 
 def test_valid_routing_mode_does_not_log_warning(config):
     """Valid routing_mode should not log a warning."""
-    config["ollama"]["routing_mode"] = "claude_only"
+    config["local"]["routing_mode"] = "cloud"
     guardrails = Guardrails(config)
     with patch("logging.Logger.warning") as mock_warning:
         r = Router(config=config, guardrails=guardrails)
@@ -147,66 +154,66 @@ def test_valid_routing_mode_does_not_log_warning(config):
 
 # ── pre-flight classifier ──────────────────────────────────────────────────────
 
-def test_classifier_routes_local_task_to_ollama(config):
-    """read_only + can_handle_locally=True → OllamaAgent, no Claude call."""
-    config["ollama"]["routing_mode"] = "ollama_first"
+def test_classifier_routes_local_task_to_local(config):
+    """read_only + can_handle_locally=True → LocalAgent, no cloud call."""
+    config["local"]["routing_mode"] = "automatic"
     guardrails = Guardrails(config)
     r = Router(config=config, guardrails=guardrails)
 
-    mock_ollama = MagicMock()
-    mock_claude = MagicMock()
-    mock_ollama.run.return_value = {"speak": "Done.", "display": "Done."}
-    r._ollama = mock_ollama
-    r._claude = mock_claude
+    mock_local = MagicMock()
+    mock_cloud = MagicMock()
+    mock_local.run.return_value = {"speak": "Done.", "display": "Done."}
+    r._local = mock_local
+    r._sonnet = mock_cloud
 
     classification = {"can_handle_locally": True, "intent_class": "read_only", "reason": "file op"}
     with patch.object(r, "_classify", return_value=classification):
         result = r.process("list my files", cwd=None)
 
-    mock_ollama.run.assert_called_once()
-    mock_claude.run.assert_not_called()
+    mock_local.run.assert_called_once()
+    mock_cloud.run.assert_not_called()
 
 
-def test_classifier_routes_complex_task_to_claude(config):
-    """can_handle_locally=False → Agent (Claude), no Ollama call."""
-    config["ollama"]["routing_mode"] = "ollama_first"
+def test_classifier_routes_complex_task_to_sonnet(config):
+    """complex_reasoning → Sonnet, no local call."""
+    config["local"]["routing_mode"] = "automatic"
     guardrails = Guardrails(config)
     r = Router(config=config, guardrails=guardrails)
 
-    mock_ollama = MagicMock()
-    mock_claude = MagicMock()
-    mock_claude.run.return_value = {"speak": "Done via Claude.", "display": "Done."}
-    r._ollama = mock_ollama
-    r._claude = mock_claude
+    mock_local = MagicMock()
+    mock_sonnet = MagicMock()
+    mock_sonnet.run.return_value = {"speak": "Done via Sonnet.", "display": "Done."}
+    r._local = mock_local
+    r._sonnet = mock_sonnet
 
     classification = {"can_handle_locally": False, "intent_class": "complex_reasoning", "reason": "web search"}
     with patch.object(r, "_classify", return_value=classification):
         result = r.process("latest React news", cwd=None)
 
-    mock_ollama.run.assert_not_called()
-    mock_claude.run.assert_called_once()
+    mock_local.run.assert_not_called()
+    mock_sonnet.run.assert_called_once()
     assert result.get("_escalated") is False   # direct routing, not escalation
 
 
-def test_classifier_failure_falls_back_to_ollama_first(config):
-    """If _classify raises, Router falls back to ollama_first behaviour."""
-    config["ollama"]["routing_mode"] = "ollama_first"
+def test_classifier_failure_falls_back_to_local(config):
+    """If _classify raises, Router falls back to local executor."""
+    config["local"]["routing_mode"] = "automatic"
     guardrails = Guardrails(config)
     r = Router(config=config, guardrails=guardrails)
 
-    mock_ollama = MagicMock()
-    mock_claude = MagicMock()
-    mock_ollama.run.return_value = {"speak": "Done.", "display": "Done."}
-    r._ollama = mock_ollama
-    r._claude = mock_claude
+    mock_local = MagicMock()
+    mock_cloud = MagicMock()
+    mock_local.run.return_value = {"speak": "Done.", "display": "Done."}
+    r._local = mock_local
+    r._sonnet = mock_cloud
 
     with patch.object(r, "_classify", side_effect=Exception("classifier down")):
         result = r.process("open Safari", cwd=None)
 
-    mock_ollama.run.assert_called_once()   # fell back gracefully
+    mock_local.run.assert_called_once()   # fell back gracefully
 
 
-# ── routing_mode: haiku_first ─────────────────────────────────────────────────
+# ── automatic mode fixtures and tests ─────────────────────────────────────────
 
 @pytest.fixture
 def mock_haiku_agent():
@@ -223,220 +230,156 @@ def mock_sonnet_agent():
 
 
 @pytest.fixture
-def haiku_router(config, mock_ollama_agent, mock_haiku_agent, mock_sonnet_agent):
-    config["ollama"]["routing_mode"] = "haiku_first"
+def automatic_router(config, mock_local_agent, mock_haiku_agent, mock_sonnet_agent):
+    config["local"]["routing_mode"] = "automatic"
+    config["local"]["model"] = "qwen-executor"
+    config["local"]["executor_model"] = "supergemma4-test"
+    config["local"]["classifier_model"] = "mlx-community/Qwen3-4B-Instruct-2507-4bit"
     guardrails = Guardrails(config)
     r = Router(config=config, guardrails=guardrails)
-    r._ollama = mock_ollama_agent
+    r._local = mock_local_agent
     r._haiku = mock_haiku_agent
     r._sonnet = mock_sonnet_agent
+    r._claude = mock_sonnet_agent
     r._classify = MagicMock(return_value={"can_handle_locally": True, "intent_class": "read_only", "reason": "test"})
     return r
 
 
-def test_haiku_first_uses_haiku_for_simple_tasks(haiku_router, mock_haiku_agent, mock_sonnet_agent, mock_ollama_agent):
-    result = haiku_router.process("list my files")
-    mock_haiku_agent.run.assert_called_once()
+def test_automatic_uses_local_for_simple_tasks(automatic_router, mock_local_agent, mock_sonnet_agent):
+    result = automatic_router.process("list my files")
+    mock_local_agent.run.assert_called_once()
     mock_sonnet_agent.run.assert_not_called()
-    mock_ollama_agent.run.assert_not_called()
-    assert result["speak"] == "Done via Haiku."
-    assert result["_model"] == "claude-haiku-4-5-20251001"
-
-
-def test_haiku_first_uses_sonnet_for_complex_reasoning(haiku_router, mock_haiku_agent, mock_sonnet_agent):
-    haiku_router._classify = MagicMock(return_value={
-        "can_handle_locally": False, "intent_class": "complex_reasoning", "reason": "needs web"
-    })
-    result = haiku_router.process("what's the latest news on AI?")
-    mock_sonnet_agent.run.assert_called_once()
-    mock_haiku_agent.run.assert_not_called()
-    assert result["_model"] == "claude-sonnet-4-6"
-
-
-def test_config_fixture_default_routing_mode_is_local_first(config):
-    assert config["ollama"]["routing_mode"] == "local_first"
-
-
-def test_haiku_first_classifier_failure_falls_back_to_haiku(haiku_router, mock_haiku_agent, mock_sonnet_agent):
-    haiku_router._classify = MagicMock(side_effect=Exception("classifier down"))
-    result = haiku_router.process("hello")
-    mock_haiku_agent.run.assert_called_once()
-    mock_sonnet_agent.run.assert_not_called()
-
-
-def test_router_passes_step_callback_to_agent(haiku_router):
-    """Router forwards step_callback kwarg to agent.run()."""
-    cb = MagicMock()
-    with patch.object(haiku_router._haiku, "run", return_value={
-        "speak": "ok", "display": "ok", "steps": []
-    }) as mock_run:
-        haiku_router.process("hello", step_callback=cb)
-    mock_run.assert_called_once()
-    assert mock_run.call_args.kwargs.get("step_callback") == cb
-
-
-def test_intent_class_destructive_annotated_in_metadata(config):
-    """Destructive intent class should appear in response metadata."""
-    config["ollama"]["routing_mode"] = "ollama_first"
-    guardrails = Guardrails(config)
-    r = Router(config=config, guardrails=guardrails)
-
-    mock_ollama = MagicMock()
-    mock_claude = MagicMock()
-    mock_ollama.run.return_value = {"speak": "Done.", "display": "Done."}
-    r._ollama = mock_ollama
-    r._claude = mock_claude
-
-    classification = {"can_handle_locally": True, "intent_class": "destructive", "reason": "deletes file"}
-    with patch.object(r, "_classify", return_value=classification):
-        result = r.process("delete temp files", cwd=None)
-
-    assert result.get("_intent_class") == "destructive"
-
-
-# ── routing_mode: local_first ────────────────────────────────────────────────
-
-@pytest.fixture
-def local_first_router(config, mock_ollama_agent, mock_haiku_agent, mock_sonnet_agent):
-    config["ollama"]["routing_mode"] = "local_first"
-    config["ollama"]["model"] = "qwen-executor"
-    config["ollama"]["executor_model"] = "supergemma4-test"
-    config["ollama"]["classifier_model"] = "mlx-community/Qwen3-4B-Instruct-2507-4bit"
-    guardrails = Guardrails(config)
-    r = Router(config=config, guardrails=guardrails)
-    r._ollama = mock_ollama_agent
-    r._haiku = mock_haiku_agent
-    r._sonnet = mock_sonnet_agent
-    r._claude = mock_sonnet_agent
-    return r
-
-
-def test_local_first_uses_ollama_for_simple_tasks(local_first_router, mock_ollama_agent, mock_sonnet_agent):
-    result = local_first_router.process("list my files")
-    mock_ollama_agent.run.assert_called_once()
-    mock_sonnet_agent.run.assert_not_called()
-    assert result["_agent"] == "ollama"
+    assert result["_agent"] == "local"
     assert result["_model"] == "supergemma4-test"
 
 
-def test_local_first_uses_sonnet_for_complex_reasoning(local_first_router, mock_ollama_agent, mock_sonnet_agent):
-    local_first_router._classify = MagicMock(return_value={
+def test_automatic_uses_sonnet_for_complex_reasoning(automatic_router, mock_local_agent, mock_sonnet_agent):
+    automatic_router._classify = MagicMock(return_value={
         "can_handle_locally": False, "intent_class": "complex_reasoning", "reason": "needs web"
     })
-    result = local_first_router.process("search the web for latest news")
-    mock_ollama_agent.run.assert_not_called()
+    result = automatic_router.process("search the web for latest news")
+    mock_local_agent.run.assert_not_called()
     mock_sonnet_agent.run.assert_called_once()
     assert result["_agent"] == "claude"
     assert result["_model"] == "claude-sonnet-4-6"
 
 
-def test_local_first_stays_local_on_escalate(local_first_router, mock_ollama_agent, mock_sonnet_agent):
-    """In local_first mode, OllamaAgent failure must return a graceful message — never call cloud."""
-    from local_agent import EscalateToCloud
-    local_first_router._classify = MagicMock(return_value={
+def test_automatic_stays_local_on_escalate_suppressed_by_local_mode(config, mock_local_agent, mock_sonnet_agent):
+    """In local mode, EscalateToCloud must return graceful message — never call cloud."""
+    config["local"]["routing_mode"] = "local"
+    guardrails = Guardrails(config)
+    r = Router(config=config, guardrails=guardrails)
+    r._local = mock_local_agent
+    r._sonnet = mock_sonnet_agent
+    r._classify = MagicMock(return_value={
         "can_handle_locally": True, "intent_class": "read_only", "reason": "simple"
     })
-    mock_ollama_agent.run.side_effect = EscalateToCloud("timeout")
-    result = local_first_router.process("do something hard")
+    mock_local_agent.run.side_effect = EscalateToCloud("timeout")
+    result = r.process("do something hard")
     mock_sonnet_agent.run.assert_not_called()
     assert result["_escalated"] is True
-    assert "local_first" in result["_escalation_reason"]
+    assert "suppressed:local" in result["_escalation_reason"]
     assert result["speak"] is not None
 
 
-def test_local_first_classifier_failure_falls_back_to_ollama(local_first_router, mock_ollama_agent, mock_sonnet_agent):
-    local_first_router._classify = MagicMock(side_effect=Exception("classifier down"))
-    result = local_first_router.process("hello")
-    mock_ollama_agent.run.assert_called_once()
+def test_automatic_classifier_failure_falls_back_to_local(automatic_router, mock_local_agent, mock_sonnet_agent):
+    automatic_router._classify = MagicMock(side_effect=Exception("classifier down"))
+    result = automatic_router.process("hello")
+    mock_local_agent.run.assert_called_once()
     mock_sonnet_agent.run.assert_not_called()
 
 
 def test_classifier_uses_classifier_model(config):
     """_classifier_model should use classifier_model key when present."""
-    config["ollama"]["model"] = "qwen-executor"
-    config["ollama"]["classifier_model"] = "mlx-community/Qwen3-4B-Instruct-2507-4bit"
+    config["local"]["model"] = "qwen-executor"
+    config["local"]["classifier_model"] = "mlx-community/Qwen3-4B-Instruct-2507-4bit"
     guardrails = Guardrails(config)
     r = Router(config=config, guardrails=guardrails)
     assert r._classifier_model == "mlx-community/Qwen3-4B-Instruct-2507-4bit"
-    assert r._ollama_model == "qwen-executor"
+    assert r._local_model == "qwen-executor"
 
 
-def test_default_routing_mode_is_local_first():
-    """Default routing mode should be local_first."""
+def test_default_routing_mode_is_automatic(config):
+    """Default routing mode should be automatic."""
+    assert config["local"]["routing_mode"] == "automatic"
+
+
+def test_default_routing_mode_in_defaults():
+    """Default routing mode in DEFAULTS should be automatic."""
     from config import DEFAULTS
-    assert DEFAULTS["ollama"]["routing_mode"] == "local_first"
+    assert DEFAULTS["local"]["routing_mode"] == "automatic"
 
 
-def test_resume_returns_none_when_no_paused_run(haiku_router):
+def test_resume_returns_none_when_no_paused_run(automatic_router):
     import approval_store
     approval_store.clear()
-    assert haiku_router.resume("nope") is None
+    assert automatic_router.resume("nope") is None
 
 
-def test_resume_invokes_stored_resumer_and_annotates(haiku_router):
+def test_resume_invokes_stored_resumer_and_annotates(automatic_router):
     import approval_store
     approval_store.clear()
     approval_store.register(
         "c1",
         lambda step_callback=None: {"speak": "ok", "display": "ok", "steps": []},
-        {"user_text": "hi", "agent": "ollama", "model": "m1"},
+        {"user_text": "hi", "agent": "local", "model": "m1"},
     )
-    result = haiku_router.resume("c1")
-    assert result["_agent"] == "ollama"
+    result = automatic_router.resume("c1")
+    assert result["_agent"] == "local"
     assert result["_model"] == "m1"
     assert result["speak"] == "ok"
     assert not approval_store.has("c1")  # popped
 
 
-def test_default_base_ollama_model_is_qwen36():
-    """Default base Ollama model should align with the selected Qwen executor."""
+def test_default_base_local_model_is_qwen36():
+    """Default base local model should align with the selected Qwen executor."""
     from config import DEFAULTS
-    assert DEFAULTS["ollama"]["model"] == "qwen3.6:35b-a3b"
+    assert DEFAULTS["local"]["model"] == "qwen3.6:35b-a3b"
 
 
 def test_classifier_model_in_defaults():
     """classifier_model should be present in DEFAULTS and point to jarvis-classifier."""
     from config import DEFAULTS
-    assert DEFAULTS["ollama"]["classifier_model"] == "mlx-community/Qwen3-4B-Instruct-2507-4bit"
+    assert DEFAULTS["local"]["classifier_model"] == "mlx-community/Qwen3-4B-Instruct-2507-4bit"
 
 
-def test_local_first_annotates_result_with_executor_model_name(local_first_router, mock_ollama_agent):
-    """_model in result should reflect the ollama.model (executor), not classifier_model."""
-    result = local_first_router.process("list my files")
-    assert result["_model"] == "supergemma4-test"  # matches what local_first_router fixture sets
+def test_automatic_annotates_result_with_executor_model_name(automatic_router, mock_local_agent):
+    """_model in result should reflect the local executor_model."""
+    result = automatic_router.process("list my files")
+    assert result["_model"] == "supergemma4-test"  # matches what automatic_router fixture sets
 
 
 # ── history tool summary ──────────────────────────────────────────────────────
 
-def test_history_does_not_include_tools_used_annotation(haiku_router, mock_haiku_agent):
+def test_history_does_not_include_tools_used_annotation(automatic_router, mock_local_agent):
     """History must never contain [Tools used: ...] — teaching the model to emit it."""
-    mock_haiku_agent.run.return_value = {
+    mock_local_agent.run.return_value = {
         "speak": "Done.", "display": "Done.",
         "steps": [
             {"tool": "web_fetch", "input_summary": "...", "milestone": False},
             {"tool": "run_code", "input_summary": "...", "milestone": False},
         ],
     }
-    with patch.object(haiku_router, "_classify", return_value={
-        "can_handle_locally": False, "intent_class": "read_only", "reason": "test"
+    with patch.object(automatic_router, "_classify", return_value={
+        "can_handle_locally": True, "intent_class": "read_only", "reason": "test"
     }):
-        haiku_router.process("fetch github issues")
+        automatic_router.process("fetch github issues")
 
-    assistant_msg = haiku_router._history[-1]["content"]
+    assistant_msg = automatic_router._history[-1]["content"]
     assert "[Tools used:" not in assistant_msg
 
 
-def test_history_no_tools_suffix_when_no_steps(haiku_router, mock_haiku_agent):
+def test_history_no_tools_suffix_when_no_steps(automatic_router, mock_local_agent):
     """Assistant history entry has no [Tools used] suffix when steps list is empty."""
-    mock_haiku_agent.run.return_value = {
+    mock_local_agent.run.return_value = {
         "speak": "Done.", "display": "Done.", "steps": [],
     }
-    with patch.object(haiku_router, "_classify", return_value={
-        "can_handle_locally": False, "intent_class": "read_only", "reason": "test"
+    with patch.object(automatic_router, "_classify", return_value={
+        "can_handle_locally": True, "intent_class": "read_only", "reason": "test"
     }):
-        haiku_router.process("hello")
+        automatic_router.process("hello")
 
-    assistant_msg = haiku_router._history[-1]["content"]
+    assistant_msg = automatic_router._history[-1]["content"]
     assert "[Tools used:" not in assistant_msg
 
 
@@ -444,16 +387,16 @@ def test_history_no_tools_suffix_when_no_steps(haiku_router, mock_haiku_agent):
 
 def test_classify_reuses_shared_http_client(config):
     """Router._classify must use a shared httpx.Client, not create a new one each call."""
-    config["ollama"]["routing_mode"] = "local_first"
+    config["local"]["routing_mode"] = "automatic"
     guardrails = Guardrails(config)
     r = Router(config=config, guardrails=guardrails)
     assert hasattr(r, "_http_client"), "Router must have a shared _http_client"
     assert r._http_client is not None
 
 
-# ── Task 9: _append_turn, compaction, classifier context ─────────────────────
+# ── _append_turn, compaction, classifier context ──────────────────────────────
 
-def test_append_turn_stores_compressed_steps(haiku_router):
+def test_append_turn_stores_compressed_steps(automatic_router):
     result = {
         "speak": "Done.",
         "display": "Done with details.",
@@ -462,27 +405,27 @@ def test_append_turn_stores_compressed_steps(haiku_router):
             {"tool": "file_read", "input_summary": "/tmp/x.py", "result_summary": "def main(): pass"},
         ],
     }
-    haiku_router._append_turn("show me the log", result)
-    assistant_content = haiku_router._history[-1]["content"]
+    automatic_router._append_turn("show me the log", result)
+    assistant_content = automatic_router._history[-1]["content"]
     assert "shell_run" in assistant_content
     assert "abc1234 fix: prevent crash" in assistant_content
     assert "file_read" in assistant_content
 
 
-def test_append_turn_skips_approval_required(haiku_router):
+def test_append_turn_skips_approval_required(automatic_router):
     result = {"approval_required": {"tool": "shell_run"}, "steps": []}
-    haiku_router._append_turn("delete stuff", result)
-    assert haiku_router._history == []
+    automatic_router._append_turn("delete stuff", result)
+    assert automatic_router._history == []
 
 
-def test_append_turn_no_steps_stores_display_text(haiku_router):
+def test_append_turn_no_steps_stores_display_text(automatic_router):
     result = {"speak": "Hi there!", "display": "Hi there!", "steps": []}
-    haiku_router._append_turn("hello", result)
-    assert haiku_router._history[-1]["content"] == "Hi there!"
+    automatic_router._append_turn("hello", result)
+    assert automatic_router._history[-1]["content"] == "Hi there!"
 
 
 def test_classify_receives_history_context(config):
-    config["ollama"]["routing_mode"] = "local_first"
+    config["local"]["routing_mode"] = "automatic"
     guardrails = Guardrails(config)
     r = Router(config=config, guardrails=guardrails)
     history = [
@@ -507,58 +450,58 @@ def test_classify_receives_history_context(config):
     assert messages[-1]["content"] == "yes please"
 
 
-def test_compact_fires_when_tokens_exceed_threshold(haiku_router, mock_haiku_agent):
+def test_compact_fires_when_tokens_exceed_threshold(automatic_router, mock_local_agent):
     """Compaction is deferred: _append_turn sets the flag; process() triggers it."""
     large_content = "x" * 20001  # ~5000 tokens
-    haiku_router._history = [
+    automatic_router._history = [
         {"role": "user", "content": large_content},
         {"role": "assistant", "content": "response"},
     ]
     mock_response = MagicMock()
     mock_response.content = [MagicMock(text="Compact summary of the session.")]
-    mock_haiku_agent.run.return_value = {"speak": "next", "display": "next", "steps": []}
+    mock_local_agent.run.return_value = {"speak": "next", "display": "next", "steps": []}
 
     # First: _append_turn should set the deferred flag but NOT compact yet.
-    haiku_router._append_turn("another command", {"speak": "ok", "display": "ok", "steps": []})
-    assert haiku_router._needs_compaction is True
-    assert len(haiku_router._history) == 4  # not compacted yet
+    automatic_router._append_turn("another command", {"speak": "ok", "display": "ok", "steps": []})
+    assert automatic_router._needs_compaction is True
+    assert len(automatic_router._history) == 4  # not compacted yet
 
     # Second: process() triggers the deferred compact at its start.
-    with patch.object(haiku_router._anthropic_client.messages, "create", return_value=mock_response):
-        haiku_router.process("next command")
+    with patch.object(automatic_router._anthropic_client.messages, "create", return_value=mock_response):
+        automatic_router.process("next command")
 
-    assert len(haiku_router._history) == 4  # 2 compact + 2 new from process()
-    assert haiku_router._history[0]["content"] == "[Prior conversation compacted]"
-    assert "Compact summary" in haiku_router._history[1]["content"]
-    assert haiku_router._pending_compaction_notice is True
+    assert len(automatic_router._history) == 4  # 2 compact + 2 new from process()
+    assert automatic_router._history[0]["content"] == "[Prior conversation compacted]"
+    assert "Compact summary" in automatic_router._history[1]["content"]
+    assert automatic_router._pending_compaction_notice is True
 
 
-def test_compact_best_effort_on_failure(haiku_router):
-    haiku_router._history = [
+def test_compact_best_effort_on_failure(automatic_router):
+    automatic_router._history = [
         {"role": "user", "content": "hello"},
         {"role": "assistant", "content": "world"},
     ]
-    original_history = list(haiku_router._history)
-    with patch.object(haiku_router._anthropic_client.messages, "create", side_effect=Exception("network error")):
-        haiku_router._compact()
+    original_history = list(automatic_router._history)
+    with patch.object(automatic_router._anthropic_client.messages, "create", side_effect=Exception("network error")):
+        automatic_router._compact()
 
-    assert haiku_router._history == original_history
-    assert haiku_router._pending_compaction_notice is False
-    assert haiku_router._compact_failed is True  # circuit breaker set
+    assert automatic_router._history == original_history
+    assert automatic_router._pending_compaction_notice is False
+    assert automatic_router._compact_failed is True  # circuit breaker set
 
 
-def test_compaction_notice_emitted_on_next_process(haiku_router, mock_haiku_agent):
-    haiku_router._pending_compaction_notice = True
+def test_compaction_notice_emitted_on_next_process(automatic_router, mock_local_agent):
+    automatic_router._pending_compaction_notice = True
     events = []
-    mock_haiku_agent.run.return_value = {"speak": "ok", "display": "ok", "steps": []}
-    with patch.object(haiku_router, "_classify", return_value={"intent_class": "read_only", "can_handle_locally": True}):
-        haiku_router.process("do something", step_callback=events.append)
+    mock_local_agent.run.return_value = {"speak": "ok", "display": "ok", "steps": []}
+    with patch.object(automatic_router, "_classify", return_value={"intent_class": "read_only", "can_handle_locally": True}):
+        automatic_router.process("do something", step_callback=events.append)
 
     assert any(e.get("type") == "compacted" for e in events)
-    assert haiku_router._pending_compaction_notice is False
+    assert automatic_router._pending_compaction_notice is False
 
 
-# ── Task 6: PromptLoader + system prompt + user-message prefix ────────────────
+# ── PromptLoader + system prompt + user-message prefix ────────────────────────
 
 @pytest.fixture
 def mock_prompt_loader(tmp_path):
@@ -573,11 +516,11 @@ def mock_prompt_loader(tmp_path):
 
 @pytest.fixture
 def prefix_router(config, mock_prompt_loader):
-    config["ollama"]["routing_mode"] = "local_first"
+    config["local"]["routing_mode"] = "automatic"
     guardrails = Guardrails(config)
     r = Router(config=config, guardrails=guardrails, prompt_loader=mock_prompt_loader)
-    r._ollama = MagicMock()
-    r._ollama.run.return_value = {"speak": "done", "display": "done", "error": None}
+    r._local = MagicMock()
+    r._local.run.return_value = {"speak": "done", "display": "done", "error": None}
     r._sonnet = MagicMock()
     r._classify = MagicMock(return_value={"can_handle_locally": True, "intent_class": "prepare", "reason": "test"})
     return r
@@ -586,14 +529,14 @@ def prefix_router(config, mock_prompt_loader):
 def test_user_message_includes_cwd_on_first_call(prefix_router):
     with patch("router.get_git_context", return_value=None):
         prefix_router.process("do something", cwd="/some/project")
-    call_kwargs = prefix_router._ollama.run.call_args.kwargs
+    call_kwargs = prefix_router._local.run.call_args.kwargs
     assert "[cwd: /some/project]" in call_kwargs["user_text"]
 
 
 def test_user_message_includes_date(prefix_router):
     with patch("router.get_git_context", return_value=None):
         prefix_router.process("do something", cwd="/some/project")
-    call_kwargs = prefix_router._ollama.run.call_args.kwargs
+    call_kwargs = prefix_router._local.run.call_args.kwargs
     assert f"[Date: {date.today()}]" in call_kwargs["user_text"]
 
 
@@ -601,7 +544,7 @@ def test_git_context_injected_on_first_call(prefix_router):
     ctx = {"branch": "main", "commits": ["abc feat: x"], "remote": "https://github.com/u/r"}
     with patch("router.get_git_context", return_value=ctx):
         prefix_router.process("do something", cwd="/repo")
-    call_kwargs = prefix_router._ollama.run.call_args.kwargs
+    call_kwargs = prefix_router._local.run.call_args.kwargs
     assert "branch=main" in call_kwargs["user_text"]
 
 
@@ -609,9 +552,9 @@ def test_git_context_not_repeated_when_unchanged(prefix_router):
     ctx = {"branch": "main", "commits": ["abc feat: x"], "remote": "https://github.com/u/r"}
     with patch("router.get_git_context", return_value=ctx):
         prefix_router.process("first", cwd="/repo")
-        prefix_router._ollama.run.reset_mock()
+        prefix_router._local.run.reset_mock()
         prefix_router.process("second", cwd="/repo")
-    call_kwargs = prefix_router._ollama.run.call_args.kwargs
+    call_kwargs = prefix_router._local.run.call_args.kwargs
     assert "branch=main" not in call_kwargs["user_text"]
 
 
@@ -620,16 +563,16 @@ def test_git_context_re_injected_on_branch_change(prefix_router):
     ctx2 = {"branch": "feature/y", "commits": ["def feat: y"], "remote": None}
     with patch("router.get_git_context", side_effect=[ctx1, ctx2]):
         prefix_router.process("first", cwd="/repo")
-        prefix_router._ollama.run.reset_mock()
+        prefix_router._local.run.reset_mock()
         prefix_router.process("second", cwd="/repo")
-    call_kwargs = prefix_router._ollama.run.call_args.kwargs
+    call_kwargs = prefix_router._local.run.call_args.kwargs
     assert "branch=feature/y" in call_kwargs["user_text"]
 
 
 def test_system_prompt_passed_to_agent(prefix_router):
     with patch("router.get_git_context", return_value=None):
         prefix_router.process("do something", cwd="/repo")
-    call_kwargs = prefix_router._ollama.run.call_args.kwargs
+    call_kwargs = prefix_router._local.run.call_args.kwargs
     assert call_kwargs.get("system_prompt") is not None
     assert "base prompt" in call_kwargs["system_prompt"]
 
@@ -644,81 +587,113 @@ def test_git_context_skipped_for_read_only_intent(prefix_router):
 
 # ── destructive intent approval gate ─────────────────────────────────────────
 
-def test_destructive_intent_returns_approval_required(haiku_router, mock_haiku_agent):
+def test_destructive_intent_returns_approval_required(automatic_router, mock_local_agent):
     """A destructive command must pause and return approval_required before running."""
-    haiku_router._classify = MagicMock(return_value={
+    automatic_router._classify = MagicMock(return_value={
         "can_handle_locally": True, "intent_class": "destructive", "reason": "deletes files"
     })
-    result = haiku_router.process("delete all temp files", command_id="cmd-1")
+    result = automatic_router.process("delete all temp files", command_id="cmd-1")
     assert "approval_required" in result
     assert result["approval_required"]["category"] == "destructive_command"
-    mock_haiku_agent.run.assert_not_called()
+    mock_local_agent.run.assert_not_called()
 
 
-def test_destructive_intent_registers_resume_in_approval_store(haiku_router):
+def test_destructive_intent_registers_resume_in_approval_store(automatic_router):
     """Paused destructive command must be registered so resume() can continue it."""
     import approval_store
     approval_store.clear()
-    haiku_router._classify = MagicMock(return_value={
+    automatic_router._classify = MagicMock(return_value={
         "can_handle_locally": True, "intent_class": "destructive", "reason": "rm -rf"
     })
-    haiku_router.process("wipe the build directory", command_id="cmd-2")
+    automatic_router.process("wipe the build directory", command_id="cmd-2")
     assert approval_store.has("cmd-2")
 
 
-def test_destructive_intent_resume_runs_agent(haiku_router, mock_haiku_agent):
+def test_destructive_intent_resume_runs_agent(automatic_router, mock_local_agent):
     """After approval, resume() must run the agent and return an annotated result."""
     import approval_store
     approval_store.clear()
-    mock_haiku_agent.run.return_value = {"speak": "Done.", "display": "Done.", "steps": []}
-    haiku_router._classify = MagicMock(return_value={
+    mock_local_agent.run.return_value = {"speak": "Done.", "display": "Done.", "steps": []}
+    automatic_router._classify = MagicMock(return_value={
         "can_handle_locally": True, "intent_class": "destructive", "reason": "deletes"
     })
-    haiku_router.process("remove old logs", command_id="cmd-3")
+    automatic_router.process("remove old logs", command_id="cmd-3")
     assert approval_store.has("cmd-3")
 
-    result = haiku_router.resume("cmd-3")
+    result = automatic_router.resume("cmd-3")
     assert result["speak"] == "Done."
     assert result["_intent_class"] == "destructive"
-    mock_haiku_agent.run.assert_called_once()
+    mock_local_agent.run.assert_called_once()
     assert not approval_store.has("cmd-3")
 
 
-def test_non_destructive_intent_runs_without_gate(haiku_router, mock_haiku_agent):
+def test_non_destructive_intent_runs_without_gate(automatic_router, mock_local_agent):
     """Non-destructive commands must not be gated — agent runs immediately."""
     import approval_store
     approval_store.clear()
-    haiku_router._classify = MagicMock(return_value={
+    automatic_router._classify = MagicMock(return_value={
         "can_handle_locally": True, "intent_class": "prepare", "reason": "read-ish"
     })
-    result = haiku_router.process("list all files", command_id="cmd-4")
+    result = automatic_router.process("list all files", command_id="cmd-4")
     assert "approval_required" not in result
-    mock_haiku_agent.run.assert_called_once()
+    mock_local_agent.run.assert_called_once()
     assert not approval_store.has("cmd-4")
 
 
-def test_destructive_without_command_id_runs_immediately(haiku_router, mock_haiku_agent):
+def test_destructive_without_command_id_runs_immediately(automatic_router, mock_local_agent):
     """Without a command_id there's no way to resume, so run immediately (no gate)."""
-    haiku_router._classify = MagicMock(return_value={
+    automatic_router._classify = MagicMock(return_value={
         "can_handle_locally": True, "intent_class": "destructive", "reason": "deletes"
     })
-    result = haiku_router.process("delete build artifacts")  # no command_id
+    result = automatic_router.process("delete build artifacts")  # no command_id
     assert "approval_required" not in result
-    mock_haiku_agent.run.assert_called_once()
+    mock_local_agent.run.assert_called_once()
 
 
-def test_destructive_gate_in_ollama_first_mode(config, mock_ollama_agent):
-    """ollama_first routing must also gate destructive commands."""
+def test_destructive_gate_in_automatic_mode(config, mock_local_agent):
+    """automatic routing must also gate destructive commands."""
     import approval_store
     approval_store.clear()
-    config["ollama"]["routing_mode"] = "ollama_first"
+    config["local"]["routing_mode"] = "automatic"
     guardrails = Guardrails(config)
     r = Router(config=config, guardrails=guardrails)
-    r._ollama = mock_ollama_agent
+    r._local = mock_local_agent
     r._classify = MagicMock(return_value={
         "can_handle_locally": True, "intent_class": "destructive", "reason": "rm"
     })
     result = r.process("clean the repo", command_id="cmd-5")
     assert "approval_required" in result
-    mock_ollama_agent.run.assert_not_called()
+    mock_local_agent.run.assert_not_called()
     assert approval_store.has("cmd-5")
+
+
+# ── router_passes_step_callback ───────────────────────────────────────────────
+
+def test_router_passes_step_callback_to_agent(automatic_router):
+    """Router forwards step_callback kwarg to agent.run()."""
+    cb = MagicMock()
+    with patch.object(automatic_router._local, "run", return_value={
+        "speak": "ok", "display": "ok", "steps": []
+    }) as mock_run:
+        automatic_router.process("hello", step_callback=cb)
+    mock_run.assert_called_once()
+    assert mock_run.call_args.kwargs.get("step_callback") == cb
+
+
+# ── intent_class destructive annotation ───────────────────────────────────────
+
+def test_intent_class_destructive_annotated_in_metadata(config):
+    """Destructive intent class should appear in response metadata."""
+    config["local"]["routing_mode"] = "automatic"
+    guardrails = Guardrails(config)
+    r = Router(config=config, guardrails=guardrails)
+
+    mock_local = MagicMock()
+    mock_local.run.return_value = {"speak": "Done.", "display": "Done."}
+    r._local = mock_local
+
+    classification = {"can_handle_locally": True, "intent_class": "destructive", "reason": "deletes file"}
+    with patch.object(r, "_classify", return_value=classification):
+        result = r.process("delete temp files", cwd=None)
+
+    assert result.get("_intent_class") == "destructive"

--- a/jarvis-core/tests/test_server.py
+++ b/jarvis-core/tests/test_server.py
@@ -205,8 +205,8 @@ def test_ensure_executor_server_running_skips_when_executor_uses_ollama_host(cli
     import server as srv
 
     cfg = {
-        "ollama": {
-            "routing_mode": "local_first",
+        "local": {
+            "routing_mode": "automatic",
             "host": "http://localhost:11434",
             "executor_host": "http://localhost:11434",
             "executor_model": "qwen3.6:35b-a3b",
@@ -221,7 +221,7 @@ def test_ensure_classifier_server_running_skips_when_uses_ollama_host(client_and
     import server as srv
 
     cfg = {
-        "ollama": {
+        "local": {
             "host": "http://localhost:11434",
             "classifier_host": "http://localhost:11434",
             "classifier_model": "some-model",
@@ -236,7 +236,7 @@ def test_ensure_classifier_server_running_starts_server_without_adapter(client_a
     import server as srv
 
     cfg = {
-        "ollama": {
+        "local": {
             "host": "http://localhost:11434",
             "classifier_host": "http://127.0.0.1:8090",
             "classifier_model": "mlx-community/Qwen3-4B-Instruct-2507-4bit",
@@ -263,7 +263,7 @@ def test_ensure_classifier_server_running_includes_adapter_path_when_configured(
     (tmp_path / "classifier_adapters").mkdir()
 
     cfg = {
-        "ollama": {
+        "local": {
             "host": "http://localhost:11434",
             "classifier_host": "http://127.0.0.1:8090",
             "classifier_model": "mlx-community/Qwen3-4B-Instruct-2507-4bit",
@@ -284,7 +284,7 @@ def test_ensure_classifier_server_running_skips_adapter_path_when_dir_missing(cl
     import server as srv
 
     cfg = {
-        "ollama": {
+        "local": {
             "host": "http://localhost:11434",
             "classifier_host": "http://127.0.0.1:8090",
             "classifier_model": "mlx-community/Qwen3-4B-Instruct-2507-4bit",
@@ -304,7 +304,7 @@ def test_ensure_classifier_server_running_skips_if_already_running(client_and_ag
     import server as srv
 
     cfg = {
-        "ollama": {
+        "local": {
             "host": "http://localhost:11434",
             "classifier_host": "http://127.0.0.1:8090",
             "classifier_model": "mlx-community/Qwen3-4B-Instruct-2507-4bit",

--- a/jarvis-core/tests/test_tools_coding_agent.py
+++ b/jarvis-core/tests/test_tools_coding_agent.py
@@ -7,7 +7,7 @@ from tools.coding_agent import CodingAgentTool
 CONFIG = {
     "anthropic_api_key": "sk-test",
     "models": {"haiku": "claude-haiku-4-5-20251001"},
-    "ollama": {"host": "http://localhost:11434"},
+    "local": {"host": "http://localhost:11434"},
 }
 
 
@@ -30,9 +30,9 @@ def test_init_creates_components():
     )
 
 
-def test_init_sets_force_local_when_routing_mode_is_ollama_only():
-    """CodingAgentTool sets force_local=True on HybridClient when routing_mode is ollama_only."""
-    config = {**CONFIG, "local_model": "qwen3-coder:30b", "ollama": {**CONFIG["ollama"], "routing_mode": "ollama_only"}}
+def test_init_sets_force_local_when_routing_mode_is_local():
+    """CodingAgentTool sets force_local=True on HybridClient when routing_mode is 'local'."""
+    config = {**CONFIG, "local_model": "qwen3-coder:30b", "local": {**CONFIG["local"], "routing_mode": "local"}}
     with patch("tools.coding_agent.ClaudeClient"), \
          patch("tools.coding_agent.OllamaClient"), \
          patch("tools.coding_agent.HybridClient") as MockHybrid, \
@@ -41,9 +41,9 @@ def test_init_sets_force_local_when_routing_mode_is_ollama_only():
     assert MockHybrid.return_value.force_local is True
 
 
-def test_init_does_not_set_force_local_when_routing_mode_is_local_first():
-    """CodingAgentTool leaves force_local=False when routing_mode is local_first."""
-    config = {**CONFIG, "local_model": "qwen3-coder:30b", "ollama": {**CONFIG["ollama"], "routing_mode": "local_first"}}
+def test_init_does_not_set_force_local_when_routing_mode_is_automatic():
+    """CodingAgentTool leaves force_local=False when routing_mode is 'automatic'."""
+    config = {**CONFIG, "local_model": "qwen3-coder:30b", "local": {**CONFIG["local"], "routing_mode": "automatic"}}
     with patch("tools.coding_agent.ClaudeClient"), \
          patch("tools.coding_agent.OllamaClient"), \
          patch("tools.coding_agent.HybridClient") as MockHybrid, \

--- a/jarvis-core/tools/coding_agent.py
+++ b/jarvis-core/tools/coding_agent.py
@@ -26,7 +26,7 @@ _PLANS_DIR = os.path.expanduser("~/.jarvis/coding-agent-plans")
 
 class CodingAgentTool:
     def __init__(self, config: dict):
-        ollama_host = config.get("ollama", {}).get("host", "http://localhost:11434")
+        ollama_host = config.get("local", {}).get("host", "http://localhost:11434")
         claude = ClaudeClient(
             model=config.get("models", {}).get("haiku", "claude-haiku-4-5-20251001"),
             api_key=config["anthropic_api_key"],
@@ -37,7 +37,7 @@ class CodingAgentTool:
                 ollama=OllamaClient(model=local_model, base_url=ollama_host),
                 claude=claude,
             )
-            if config.get("ollama", {}).get("routing_mode") == "ollama_only":
+            if config.get("local", {}).get("routing_mode") == "local":
                 hybrid.force_local = True
             self._llm = hybrid
         else:


### PR DESCRIPTION
## Summary

- **Security:** Removed `config.dev.json` from repo (contained live Anthropic + Telegram secrets). `~/.jarvis/config.json` is now the sole config source.
- **Rename:** All `"ollama"` identifiers renamed to `"local"` — provider-agnostic naming since Jarvis can serve from any backend.
  - `ollama_agent.py` → `local_agent.py`; `OllamaAgent` → `LocalAgent`
  - Config key `"ollama"` → `"local"`; `max_steps_ollama` → `max_steps_local`
  - `self._ollama` (Router) → `self._local`; `agent="ollama"` → `agent="local"`
  - `ollama_available` (Agent) → `local_available`
  - `_ensure_ollama_running()` → `_ensure_local_executor_running()`
- **Mode consolidation:** Five routing modes → three:
  - `local_first` → `automatic` (default: classifier pre-flights; non-complex→local, complex_reasoning→Sonnet)
  - `ollama_only` → `local` (everything local, zero cloud)
  - `claude_only` → `cloud` (skip classifier, straight to Sonnet)
  - `ollama_first`, `haiku_first` → removed entirely

## Migration (automatic, no user action required)

Existing `~/.jarvis/config.json` is auto-migrated on first load:
- `"ollama"` key silently renamed to `"local"` on read
- Old mode values (`local_first`, `ollama_only`, `claude_only`, `ollama_first`, `haiku_first`) mapped to new values
- `max_steps_ollama` → `max_steps_local`
- Analytics log will now show `_agent: "local"` instead of `"ollama"`

## Test plan

- [ ] `pytest` passes locally (479/479 ✅)
- [ ] Confirm `~/.jarvis/config.json` loads correctly after update (auto-migrated ✅)
- [ ] Start Jarvis, send a voice command — confirm routing works in `automatic` mode
- [ ] Confirm no regressions in streaming, escalation, or abort flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)