### PR TITLE
fix: sync settings panel to current config shape (local key, 3 routing modes)

### DIFF
--- a/jarvis-swift/Jarvis/SettingsView.swift
+++ b/jarvis-swift/Jarvis/SettingsView.swift
@@ -172,7 +172,7 @@ struct SettingsView: View {
     private func showRestartAlert() {
         let alert = NSAlert()
         alert.messageText = "Restart Required"
-        alert.informativeText = "Some changes (routing mode, Ollama host, or model IDs) require a server restart to take effect."
+        alert.informativeText = "Some changes (routing mode, local executor host, or model IDs) require a server restart to take effect."
         alert.addButton(withTitle: "Restart Now")
         alert.addButton(withTitle: "Later")
         let response = alert.runModal()
@@ -271,33 +271,56 @@ private struct GeneralSection: View {
 
 private struct AISection: View {
     @ObservedObject var vm: SettingsViewModel
-    private let routingModes = ["haiku_first", "ollama_first", "claude_only", "ollama_only"]
+
+    private struct ModeOption: Identifiable {
+        let id: String
+        let label: String
+        let description: String
+    }
+
+    private let routingModes: [ModeOption] = [
+        ModeOption(id: "automatic", label: "Automatic",
+                   description: "Classifier pre-flights intent. Non-complex → local model. Complex reasoning → Sonnet."),
+        ModeOption(id: "local",     label: "Local only",
+                   description: "Everything runs on the local model. No cloud API calls."),
+        ModeOption(id: "cloud",     label: "Cloud only",
+                   description: "Skip classifier, send everything directly to Sonnet."),
+    ]
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             SectionHeader(title: "AI & Routing")
             SettingRow("Routing mode",
-                       tooltip: "haiku_first: Ollama classifies intent, routes to Haiku or Sonnet. claude_only: always Claude, no Ollama. ollama_only: local model only, no API calls.",
+                       tooltip: "automatic: classifier routes simple tasks to the local model, complex tasks to Sonnet. local: no cloud at all. cloud: always Sonnet.",
                        restartRequired: true) {
                 Picker("", selection: $vm.routingMode) {
-                    ForEach(routingModes, id: \.self) { Text($0).tag($0) }
+                    ForEach(routingModes) { mode in
+                        Text(mode.label).tag(mode.id)
+                    }
                 }
                 .labelsHidden().frame(width: 140)
             }
-            SettingRow("Ollama host",
+            if let selected = routingModes.first(where: { $0.id == vm.routingMode }) {
+                Text(selected.description)
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                    .padding(.bottom, 8)
+            }
+            SettingRow("Local executor host",
                        tooltip: "URL of your Ollama instance. Default is localhost. Change if running Ollama on a remote machine.",
                        restartRequired: true) {
-                TextField("http://localhost:11434", text: $vm.ollamaHost)
+                TextField("http://localhost:11434", text: $vm.localHost)
                     .textFieldStyle(.roundedBorder).frame(width: 180)
             }
-            SettingRow("Ollama model",
-                       tooltip: "Local model used for intent classification. llama3.1:8b gives the best accuracy. Must be pulled via 'ollama pull'.") {
-                TextField("llama3.1:8b", text: $vm.ollamaModel)
-                    .textFieldStyle(.roundedBorder).frame(width: 140)
+            SettingRow("Local executor model",
+                       tooltip: "The local model served by Ollama/MLX used as primary executor. Must be pulled via 'ollama pull'.") {
+                TextField("qwen3.6:35b-a3b", text: $vm.localModel)
+                    .textFieldStyle(.roundedBorder).frame(width: 180)
             }
-            SettingRow("Ollama timeout (s)",
-                       tooltip: "How long to wait for Ollama before falling back to Claude. Lower = faster fallback.") {
-                Stepper("\(vm.ollamaTimeout)s", value: $vm.ollamaTimeout, in: 5...120, step: 5)
-                    .frame(width: 100)
+            SettingRow("Local executor timeout (s)",
+                       tooltip: "How long to wait for the local model before giving up. Default 300s for large models.") {
+                Stepper("\(vm.localTimeout)s", value: $vm.localTimeout, in: 30...600, step: 30)
+                    .frame(width: 110)
             }
             Text("↺ fields require a server restart to take effect.")
                 .font(.system(size: 11))
@@ -421,14 +444,9 @@ private struct AdvancedSection: View {
                 Stepper("\(vm.maxStepsClaude)", value: $vm.maxStepsClaude, in: 1...30)
                     .frame(width: 80)
             }
-            SettingRow("Max Ollama steps",
-                       tooltip: "How many tool calls the local Ollama agent can make per sub-task.") {
-                Stepper("\(vm.maxStepsOllama)", value: $vm.maxStepsOllama, in: 1...20)
-                    .frame(width: 80)
-            }
-            SettingRow("Max total steps",
-                       tooltip: "Hard cap across all agents in a single command. Prevents runaway execution.") {
-                Stepper("\(vm.maxTotalSteps)", value: $vm.maxTotalSteps, in: 1...50)
+            SettingRow("Max local steps",
+                       tooltip: "How many tool calls the local model can make per command.") {
+                Stepper("\(vm.maxStepsLocal)", value: $vm.maxStepsLocal, in: 1...30)
                     .frame(width: 80)
             }
             SettingRow("Stall detection",

--- a/jarvis-swift/Jarvis/SettingsViewModel.swift
+++ b/jarvis-swift/Jarvis/SettingsViewModel.swift
@@ -12,10 +12,10 @@ final class SettingsViewModel: ObservableObject {
     @Published var alwaysOn: Bool = false
 
     // MARK: - AI & Routing
-    @Published var routingMode: String = "haiku_first"
-    @Published var ollamaHost: String = "http://localhost:11434"
-    @Published var ollamaModel: String = "llama3.1:8b"
-    @Published var ollamaTimeout: Int = 30
+    @Published var routingMode: String = "automatic"
+    @Published var localHost: String = "http://localhost:11434"
+    @Published var localModel: String = "qwen3.6:35b-a3b"
+    @Published var localTimeout: Int = 300
 
     // MARK: - Telegram
     @Published var telegramBotToken: String = ""
@@ -40,9 +40,8 @@ final class SettingsViewModel: ObservableObject {
 
     // MARK: - Advanced
     @Published var serverPort: Int = 8765
-    @Published var maxStepsClaude: Int = 10
-    @Published var maxStepsOllama: Int = 5
-    @Published var maxTotalSteps: Int = 20
+    @Published var maxStepsClaude: Int = 15
+    @Published var maxStepsLocal: Int = 15
     @Published var stallDetection: Bool = true
     @Published var haikuModel: String = "claude-haiku-4-5-20251001"
     @Published var sonnetModel: String = "claude-sonnet-4-6"
@@ -92,12 +91,12 @@ final class SettingsViewModel: ObservableObject {
         alwaysOn  = json["always_on"]  as? Bool   ?? false
         // anthropicApiKey, braveApiKey stay blank (server redacts them)
 
-        // AI & Routing
-        if let ollama = json["ollama"] as? [String: Any] {
-            routingMode   = ollama["routing_mode"]    as? String ?? "haiku_first"
-            ollamaHost    = ollama["host"]            as? String ?? "http://localhost:11434"
-            ollamaModel   = ollama["model"]           as? String ?? "llama3.1:8b"
-            ollamaTimeout = ollama["timeout_seconds"] as? Int    ?? 30
+        // AI & Routing — config key is "local" (renamed from "ollama" in PR #47)
+        if let local = json["local"] as? [String: Any] {
+            routingMode  = local["routing_mode"]    as? String ?? "automatic"
+            localHost    = local["host"]            as? String ?? "http://localhost:11434"
+            localModel   = local["model"]           as? String ?? "qwen3.6:35b-a3b"
+            localTimeout = local["timeout_seconds"] as? Int    ?? 300
         }
 
         // Telegram — bot_token always starts blank (server redacts it)
@@ -130,9 +129,8 @@ final class SettingsViewModel: ObservableObject {
         // Advanced
         serverPort = json["server_port"] as? Int ?? 8765
         if let reasoning = json["reasoning"] as? [String: Any] {
-            maxStepsClaude = reasoning["max_steps_claude"] as? Int  ?? 10
-            maxStepsOllama = reasoning["max_steps_ollama"] as? Int  ?? 5
-            maxTotalSteps  = reasoning["max_total_steps"]  as? Int  ?? 20
+            maxStepsClaude = reasoning["max_steps_claude"] as? Int  ?? 15
+            maxStepsLocal  = reasoning["max_steps_local"]  as? Int  ?? 15
             stallDetection = reasoning["stall_detection"]  as? Bool ?? true
         }
         if let models = json["models"] as? [String: Any] {
@@ -143,11 +141,11 @@ final class SettingsViewModel: ObservableObject {
 
     private func snapshotRestartValues() {
         loadedRestartValues = [
-            "server_port":         "\(serverPort)",
-            "ollama.routing_mode": routingMode,
-            "ollama.host":         ollamaHost,
-            "models.haiku":        haikuModel,
-            "models.sonnet":       sonnetModel,
+            "server_port":        "\(serverPort)",
+            "local.routing_mode": routingMode,
+            "local.host":         localHost,
+            "models.haiku":       haikuModel,
+            "models.sonnet":      sonnetModel,
         ]
     }
 
@@ -175,11 +173,11 @@ final class SettingsViewModel: ObservableObject {
 
         // Detect if any restart-required field changed
         let currentRestartValues: [String: String] = [
-            "server_port":         "\(serverPort)",
-            "ollama.routing_mode": routingMode,
-            "ollama.host":         ollamaHost,
-            "models.haiku":        haikuModel,
-            "models.sonnet":       sonnetModel,
+            "server_port":        "\(serverPort)",
+            "local.routing_mode": routingMode,
+            "local.host":         localHost,
+            "models.haiku":       haikuModel,
+            "models.sonnet":      sonnetModel,
         ]
         needsRestart = currentRestartValues != loadedRestartValues
         snapshotRestartValues()
@@ -194,11 +192,11 @@ final class SettingsViewModel: ObservableObject {
             "wake_word":   wakeWord,
             "always_on":   alwaysOn,
             "server_port": serverPort,
-            "ollama": [
+            "local": [
                 "routing_mode":    routingMode,
-                "host":            ollamaHost,
-                "model":           ollamaModel,
-                "timeout_seconds": ollamaTimeout,
+                "host":            localHost,
+                "model":           localModel,
+                "timeout_seconds": localTimeout,
             ],
             "telegram": tg,
             "narration": [
@@ -220,8 +218,7 @@ final class SettingsViewModel: ObservableObject {
             ],
             "reasoning": [
                 "max_steps_claude": maxStepsClaude,
-                "max_steps_ollama": maxStepsOllama,
-                "max_total_steps":  maxTotalSteps,
+                "max_steps_local":  maxStepsLocal,
                 "stall_detection":  stallDetection,
             ],
             "models": [


### PR DESCRIPTION
## Summary

The settings panel was reading/writing the old `"ollama"` config key and showing routing modes that no longer exist. This brings it in sync with the config shape established in PR #47.

**SettingsViewModel:**
- `applyJSON`: reads `json["local"]` instead of `json["ollama"]`; `max_steps_local` instead of `max_steps_ollama`; removed dead `max_total_steps`
- `buildPayload`: sends `"local"` key; `max_steps_local`; removed `max_total_steps`
- Field renames: `ollamaHost/Model/Timeout` → `localHost/Model/Timeout`; `maxStepsOllama` → `maxStepsLocal`
- `snapshotRestartValues`: `"ollama.*"` keys → `"local.*"` (restart detection still works)
- Default routing mode: `"haiku_first"` → `"automatic"`

**SettingsView:**
- Routing mode picker now shows 3 live options: **Automatic** / **Local only** / **Cloud only**
- Selected mode shows an inline description line so the user knows what each does
- Labels updated: "Ollama host/model/timeout" → "Local executor host/model/timeout"
- Removed dead "Max total steps" row; renamed "Max Ollama steps" → "Max local steps"
- Restart alert text updated

## Test plan

- [ ] Open Settings → AI & Routing: picker shows Automatic / Local only / Cloud only
- [ ] Change routing mode, save → confirm `~/.jarvis/config.json` `local.routing_mode` updates
- [ ] Change local executor host, save → restart prompt appears
- [ ] Non-restart changes (guardrails, narration) → no restart prompt
- [ ] Reload settings: values reflect what's in config

🤖 Generated with [Claude Code](https://claude.com/claude-code)