### PR TITLE
feat: enable text selection in HUD conversation thread

### DIFF
--- a/jarvis-swift/Jarvis/HUDView.swift
+++ b/jarvis-swift/Jarvis/HUDView.swift
@@ -357,6 +357,7 @@ struct TurnRowView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
+        .textSelection(.enabled)
     }
 
     private func stepLabel(_ step: Step) -> String {


### PR DESCRIPTION
## Summary
- Add `.textSelection(.enabled)` to `TurnRowView`'s outer `VStack` so all text in a conversation turn (command, tool steps, response) is selectable with the cursor for copying

## Test plan
- [ ] Open HUD, run a command, verify you can click-drag to select text in the response
- [ ] Verify command (blue) and tool steps (gray) are also selectable
- [ ] Verify streaming text doesn't interfere

🤖 Generated with [Claude Code](https://claude.com/claude-code)