### PR TITLE
feat: multi-step prompt guidance, log expand, desktop default launch

### DIFF
--- a/jarvis-core/local_agent.py
+++ b/jarvis-core/local_agent.py
@@ -77,7 +77,8 @@ CRITICAL RULES FOR THIS MODEL:
 - NEVER respond with "Let me check...", "I'll do...", "First I need to..." or any planning sentence without ALSO calling a tool in the same response. If you need information, call the tool NOW — do not announce that you will.
 - To read a file always call file_read — NEVER use shell_run to cat/head/tail a file.
 - Be efficient: once you have enough information to answer, stop calling tools and respond. Do NOT keep gathering extra data beyond what the user asked for.
-- You have a limited number of tool calls. Use only what is needed. Do NOT stop early if the user listed multiple actions — complete ALL of them before calling finalize().
+- Simple lookups need 1-2 tool calls. Multi-step tasks may need more. Stop as soon as you have enough to answer — do NOT keep gathering extra data beyond what the user asked for.
+- Do NOT stop early if the user listed multiple actions — complete ALL of them before calling finalize().
 - If the user's request contains multiple actions (e.g. "merge PR, checkout main, pull"), treat each as a required step. Execute them in order. Do not call finalize() until every step is done.
 - NEVER call mkdir, file_write, or any filesystem-modifying command unless the user explicitly asked you to create or write something. Answering a question does not require creating directories or files.
 - NEVER write "Actions:" or echo tool call results as text in your response. After using a tool, call finalize() with a clean answer — do not describe what you did.

--- a/jarvis-core/local_agent.py
+++ b/jarvis-core/local_agent.py
@@ -71,7 +71,8 @@ CRITICAL RULES FOR THIS MODEL:
 - NEVER respond with "Let me check...", "I'll do...", "First I need to..." or any planning sentence without ALSO calling a tool in the same response. If you need information, call the tool NOW — do not announce that you will.
 - To read a file always call file_read — NEVER use shell_run to cat/head/tail a file.
 - Be efficient: once you have enough information to answer, stop calling tools and respond. Do NOT keep gathering extra data beyond what the user asked for.
-- You have a limited number of tool calls. Use only what is needed — typically 1-3 calls. Do not explore tangents.
+- You have a limited number of tool calls. Use only what is needed. Do NOT stop early if the user listed multiple actions — complete ALL of them before calling finalize().
+- If the user's request contains multiple actions (e.g. "merge PR, checkout main, pull"), treat each as a required step. Execute them in order. Do not call finalize() until every step is done.
 - NEVER call mkdir, file_write, or any filesystem-modifying command unless the user explicitly asked you to create or write something. Answering a question does not require creating directories or files.
 - NEVER write "Actions:" or echo tool call results as text in your response. After using a tool, call finalize() with a clean answer — do not describe what you did.
 """

--- a/jarvis-core/local_agent.py
+++ b/jarvis-core/local_agent.py
@@ -51,6 +51,8 @@ def _is_planning_text(text: str) -> bool:
 
 _ACTION_TRACE_RE = re.compile(r'^actions\s*:', re.IGNORECASE)
 _VO_PREFIX_RE = re.compile(r'^vo\s*:', re.IGNORECASE)
+# Matches hallucinated tool-dispatch JSON blobs (e.g. {"runId":..., "pending":[...]})
+_TOOL_JSON_RE = re.compile(r'^\{+\s*"(runId|toolUses|pending|tool_calls|function_call)"', re.IGNORECASE)
 
 
 def _is_action_trace(text: str) -> bool:
@@ -58,7 +60,11 @@ def _is_action_trace(text: str) -> bool:
     of calling finalize(). This leaks implementation details into the response and
     poisons conversational history — trigger a nudge to call finalize properly."""
     first_line = text.strip().split("\n")[0].strip()
-    return bool(_ACTION_TRACE_RE.match(first_line) or _VO_PREFIX_RE.match(first_line))
+    return bool(
+        _ACTION_TRACE_RE.match(first_line)
+        or _VO_PREFIX_RE.match(first_line)
+        or _TOOL_JSON_RE.match(first_line)
+    )
 
 
 # Appended to the base system prompt for local models that need extra guidance

--- a/jarvis-core/tests/test_local_agent.py
+++ b/jarvis-core/tests/test_local_agent.py
@@ -937,6 +937,22 @@ def test_action_trace_response_triggers_nudge_and_retry(agent):
     assert not result["speak"].startswith("Actions:"), "action trace must not leak into final answer"
 
 
+def test_hallucinated_tool_json_triggers_nudge(agent):
+    """Model returning a raw tool-dispatch JSON blob must be treated as an action trace and nudged."""
+    blob = '{"runId":"abc","toolUses":{},"pending":[{"id":"x","input":{"command":"date"},"name":"shell_run"}]}'
+    responses = [
+        _stop_response(blob),
+        _stop_response("Today is Monday."),
+    ]
+    idx = [0]
+    stream_mock = MagicMock(side_effect=ValueError("force fallback to post"))
+    with patch.object(agent._http_client, "stream", stream_mock):
+        with patch.object(agent._http_client, "post", side_effect=lambda url, json=None, **kw: (idx.__setitem__(0, idx[0]+1) or responses[idx[0]-1])):
+            result = agent.run("what day is it?")
+    assert "Monday" in result["speak"]
+    assert not result["speak"].startswith("{"), "hallucinated JSON blob must not leak into final answer"
+
+
 def test_action_trace_does_not_enter_history_as_valid_answer(agent):
     """The 'Actions:' response should be appended to messages as assistant content
     (for context) but the next user message should be a nudge, not a finalize return."""

--- a/jarvis-swift/Jarvis/AppDelegate.swift
+++ b/jarvis-swift/Jarvis/AppDelegate.swift
@@ -112,6 +112,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         installToApplicationsIfNeeded()
         checkFullDiskAccess()
         installEscKeyMonitor()
+        hudViewModel.expandToFullDesktop()
     }
 
     // MARK: - Alert Listener

--- a/jarvis-swift/Jarvis/FullDesktopView.swift
+++ b/jarvis-swift/Jarvis/FullDesktopView.swift
@@ -272,8 +272,59 @@ private func extractBetween(_ s: String, after: String, before: String) -> Strin
     return String(sub[..<b.lowerBound])
 }
 
+private func extractFull(_ s: String, after: String, before: String) -> String? {
+    guard let a = s.range(of: after) else { return nil }
+    let sub = String(s[a.upperBound...])
+    guard let b = sub.range(of: before) else { return String(sub) }
+    return String(sub[..<b.lowerBound])
+}
+
+private struct LogStep {
+    let tool: String
+    let inputSummary: String
+    let resultSummary: String
+}
+
+private func parseSteps(_ raw: String) -> [LogStep] {
+    guard let stepsStart = raw.range(of: "'steps': [") else { return [] }
+    let stepsStr = String(raw[stepsStart.upperBound...])
+    var steps: [LogStep] = []
+    var search = stepsStr
+    while let toolRange = search.range(of: "'tool': '") {
+        search = String(search[toolRange.upperBound...])
+        guard let toolEnd = search.range(of: "'") else { break }
+        let tool = String(search[..<toolEnd.lowerBound])
+        search = String(search[toolEnd.upperBound...])
+
+        // input_summary can be single or double quoted
+        let inputSummary: String
+        if let r = search.range(of: "'input_summary': \"") {
+            search = String(search[r.upperBound...])
+            inputSummary = String((search.range(of: "\", '").map { String(search[..<$0.lowerBound]) } ?? String(search.prefix(120))).prefix(120))
+        } else if let r = search.range(of: "'input_summary': '") {
+            search = String(search[r.upperBound...])
+            inputSummary = String((search.range(of: "', '").map { String(search[..<$0.lowerBound]) } ?? String(search.prefix(120))).prefix(120))
+        } else {
+            inputSummary = ""
+        }
+
+        let resultSummary: String
+        if let r = search.range(of: "'result_summary': '") {
+            search = String(search[r.upperBound...])
+            resultSummary = String((search.range(of: "', '").map { String(search[..<$0.lowerBound]) } ?? String(search.prefix(200))).prefix(200))
+        } else {
+            resultSummary = ""
+        }
+
+        steps.append(LogStep(tool: tool, inputSummary: inputSummary, resultSummary: resultSummary))
+        if steps.count > 20 { break }
+    }
+    return steps
+}
+
 struct CommandLogRow: View {
     let raw: String
+    @State private var isExpanded = false
 
     private var ts: String {
         extractBetween(raw, after: "", before: " INFO") ?? ""
@@ -304,6 +355,12 @@ struct CommandLogRow: View {
               !v.isEmpty else { return nil }
         return v
     }
+    private var displayText: String? {
+        guard let v = extractFull(raw, after: "'display': '", before: "', 'steps': ["),
+              !v.isEmpty else { return nil }
+        return v
+    }
+    private var steps: [LogStep] { parseSteps(raw) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
@@ -316,6 +373,9 @@ struct CommandLogRow: View {
                     if let ms = durationMs { pill("\(ms)ms", color: .white.opacity(0.12)) }
                     if let t = tokS        { pill("\(t) tok/s", color: logAccent.opacity(0.3)) }
                     if let i = intent      { pill(i, color: Color.purple.opacity(0.35)) }
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(logTextDim)
                 }
             }
             Text(cmd)
@@ -331,8 +391,72 @@ struct CommandLogRow: View {
                 Text(s)
                     .font(.system(size: 11))
                     .foregroundColor(logTextSecond)
-                    .lineLimit(2)
+                    .lineLimit(isExpanded ? nil : 2)
                     .textSelection(.enabled)
+            }
+
+            if isExpanded {
+                Divider().background(logRowBorder).padding(.vertical, 4)
+
+                if !steps.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("STEPS")
+                            .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                            .foregroundColor(logTextDim)
+                        ForEach(Array(steps.enumerated()), id: \.offset) { i, step in
+                            VStack(alignment: .leading, spacing: 3) {
+                                HStack(spacing: 6) {
+                                    Text("\(i + 1)")
+                                        .font(.system(size: 9, design: .monospaced))
+                                        .foregroundColor(logTextDim)
+                                    Text(step.tool)
+                                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                                        .foregroundColor(logAccent)
+                                }
+                                if !step.inputSummary.isEmpty {
+                                    Text(step.inputSummary)
+                                        .font(.system(size: 10, design: .monospaced))
+                                        .foregroundColor(logTextDim)
+                                        .textSelection(.enabled)
+                                }
+                                if !step.resultSummary.isEmpty {
+                                    Text(step.resultSummary)
+                                        .font(.system(size: 10))
+                                        .foregroundColor(logTextSecond)
+                                        .textSelection(.enabled)
+                                }
+                            }
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color.white.opacity(0.03))
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                        }
+                    }
+                }
+
+                if let display = displayText {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("RESPONSE")
+                            .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                            .foregroundColor(logTextDim)
+                        Text(display)
+                            .font(.system(size: 11))
+                            .foregroundColor(logTextSecond)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("RAW")
+                        .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                        .foregroundColor(logTextDim)
+                    Text(raw)
+                        .font(.system(size: 9, design: .monospaced))
+                        .foregroundColor(logTextDim)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
             }
         }
         .padding(12)
@@ -340,6 +464,7 @@ struct CommandLogRow: View {
         .background(logRowBg)
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .overlay(RoundedRectangle(cornerRadius: 8).stroke(logRowBorder, lineWidth: 1))
+        .onTapGesture { withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() } }
     }
 
     private func pill(_ text: String, color: Color) -> some View {


### PR DESCRIPTION
## Summary

- **Multi-step prompt fix** — updated `_LOCAL_EXTRA` in `local_agent.py` to explicitly instruct Qwen3.6 to complete all listed actions before calling `finalize()`. Removes the misleading "typically 1-3 calls" cap that could cause early termination on multi-action requests like "merge PR, checkout main, pull latest".

- **Expandable log rows** — tapping a `CommandLogRow` in the logs modal now expands to show the full request flow: numbered steps with tool name + input/result summaries, the full display response, and the raw log line for complete copy/paste.

- **Desktop mode on launch** — Jarvis now opens in full desktop mode by default instead of requiring manual activation via the menu bar.

## Test plan

- [ ] Send a multi-action command ("merge PR, checkout main, pull latest") and confirm all steps execute before finalize
- [ ] Open logs modal → Commands tab → click a row to expand, verify steps and response appear
- [ ] Verify raw log line is selectable/copyable in expanded view
- [ ] Restart Jarvis and confirm full desktop mode opens automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)